### PR TITLE
Adding iBeacon Specific Component

### DIFF
--- a/components/ibeacon.js
+++ b/components/ibeacon.js
@@ -1,0 +1,46 @@
+var config = require('config');
+var bleacon = require('bleacon');
+var console = process.console;
+
+var channel = config.get('ibeacon.channel');
+
+function iBeaconScanner(callback) {
+    // constructor
+    this.callback = callback;
+
+    this._init();
+    console.info('iBeacon scanner was initialized');
+}
+
+iBeaconScanner.prototype._init = function () {
+    bleacon.startScanning();
+    bleacon.on('discover', this._handlePacket.bind(this));
+};
+
+iBeaconScanner.prototype._handlePacket = function (ibeacon) {
+
+    // check if we have a whitelist
+    // and if we do, if this id is listed there
+    var whitelist = config.get('ibeacon.whitelist') || [];
+    if (whitelist.length == 0 || whitelist.indexOf(ibeacon.uuid) > -1) {
+
+        // max distance parameter checking
+        var maxDistance = config.get('ibeacon.max_distance') || 0;
+        if (maxDistance == 0 || ibeacon.accuracy <= maxDistance) {
+
+            var payload = {
+                id: ibeacon.uuid,
+                major: ibeacon.major,
+		minor: ibeacon.minor,
+                rssi: ibeacon.rssi,
+		distance: ibeacon.accuracy,
+		measuredpower: ibeacon.measuredPower,
+		proximity: ibeacon.proximity
+            };
+
+            this.callback(channel, payload);
+        }
+    }
+};
+
+module.exports = iBeaconScanner;

--- a/components/ibeacon.js
+++ b/components/ibeacon.js
@@ -24,12 +24,14 @@ iBeaconScanner.prototype._handlePacket = function (ibeacon) {
     var whitelist = config.get('ibeacon.whitelist') || [];
     if (whitelist.length == 0 || whitelist.indexOf(ibeacon.uuid) > -1) {
 
+	id = ibeacon.uuid + '-' + ibeacon.major + '-' + ibeacon.minor
         // max distance parameter checking
         var maxDistance = config.get('ibeacon.max_distance') || 0;
         if (maxDistance == 0 || ibeacon.accuracy <= maxDistance) {
 
             var payload = {
-                id: ibeacon.uuid,
+		id: id,
+                uuid: ibeacon.uuid,
                 major: ibeacon.major,
 		minor: ibeacon.minor,
                 rssi: ibeacon.rssi,

--- a/components/ibeacon.js
+++ b/components/ibeacon.js
@@ -24,20 +24,20 @@ iBeaconScanner.prototype._handlePacket = function (ibeacon) {
     var whitelist = config.get('ibeacon.whitelist') || [];
     if (whitelist.length == 0 || whitelist.indexOf(ibeacon.uuid) > -1) {
 
-	id = ibeacon.uuid + '-' + ibeacon.major + '-' + ibeacon.minor
+    id = ibeacon.uuid + '-' + ibeacon.major + '-' + ibeacon.minor
         // max distance parameter checking
         var maxDistance = config.get('ibeacon.max_distance') || 0;
         if (maxDistance == 0 || ibeacon.accuracy <= maxDistance) {
 
             var payload = {
-		id: id,
+        id: id,
                 uuid: ibeacon.uuid,
                 major: ibeacon.major,
-		minor: ibeacon.minor,
+        minor: ibeacon.minor,
                 rssi: ibeacon.rssi,
-		distance: ibeacon.accuracy,
-		measuredpower: ibeacon.measuredPower,
-		proximity: ibeacon.proximity
+        distance: ibeacon.accuracy,
+        measuredpower: ibeacon.measuredPower,
+        proximity: ibeacon.proximity
             };
 
             this.callback(channel, payload);

--- a/components/ibeacon.js
+++ b/components/ibeacon.js
@@ -2,11 +2,14 @@ var config = require('config');
 var bleacon = require('bleacon');
 var console = process.console;
 
+var KalmanFilter = require('kalmanjs').default;
+
 var channel = config.get('ibeacon.channel');
 
 function iBeaconScanner(callback) {
     // constructor
     this.callback = callback;
+    this.kalmanManager = {};
 
     this._init();
     console.info('iBeacon scanner was initialized');
@@ -24,25 +27,57 @@ iBeaconScanner.prototype._handlePacket = function (ibeacon) {
     var whitelist = config.get('ibeacon.whitelist') || [];
     if (whitelist.length == 0 || whitelist.indexOf(ibeacon.uuid) > -1) {
 
-    id = ibeacon.uuid + '-' + ibeacon.major + '-' + ibeacon.minor
+        // default hardcoded value for beacon tx power
+        var txPower = ibeacon.measuredPower || -59;
+        var distance = this._calculateDistance(ibeacon.rssi, txPower);
+
+        id = ibeacon.uuid + '-' + ibeacon.major + '-' + ibeacon.minor
         // max distance parameter checking
         var maxDistance = config.get('ibeacon.max_distance') || 0;
         if (maxDistance == 0 || ibeacon.accuracy <= maxDistance) {
+            var filteredDistance = this._filter(id, distance);
 
             var payload = {
-        id: id,
+		id: id,
                 uuid: ibeacon.uuid,
                 major: ibeacon.major,
-        minor: ibeacon.minor,
+		minor: ibeacon.minor,
                 rssi: ibeacon.rssi,
-        distance: ibeacon.accuracy,
-        measuredpower: ibeacon.measuredPower,
-        proximity: ibeacon.proximity
+		distance: filteredDistance,
+		accuracy: ibeacon.accuracy,
+		measuredpower: ibeacon.measuredPower,
+		proximity: ibeacon.proximity
             };
 
             this.callback(channel, payload);
         }
     }
 };
+
+iBeaconScanner.prototype._calculateDistance = function (rssi, txPower) {
+    if (rssi == 0) {
+        return -1.0;
+    }
+
+    var ratio = rssi * 1.0 / txPower;
+    if (ratio < 1.0) {
+        return Math.pow(ratio, 10);
+    }
+    else {
+        return (0.89976) * Math.pow(ratio, 7.7095) + 0.111;
+    }
+};
+
+iBeaconScanner.prototype._filter = function (id, distance) {
+    if (!this.kalmanManager.hasOwnProperty(id)) {
+        this.kalmanManager[id] = new KalmanFilter({
+            R: config.get('ibeacon.system_noise') || 0.01,
+            Q: config.get('ibeacon.measurement_noise') || 3
+        });
+    }
+
+    return this.kalmanManager[id].filter(distance);
+};
+
 
 module.exports = iBeaconScanner;

--- a/config/default.json
+++ b/config/default.json
@@ -19,6 +19,12 @@
     "system_noise": 0.01,
     "measurement_noise": 3
   },
+  "ibeacon": {
+    "enabled": false,
+    "channel": "room_presence",
+    "max_distance": 0,
+    "whitelist": []
+  },
   "temper": {
     "enabled": false,
     "channel": "temper",

--- a/config/default.json
+++ b/config/default.json
@@ -23,7 +23,9 @@
     "enabled": false,
     "channel": "room_presence",
     "max_distance": 0,
-    "whitelist": []
+    "whitelist": [],
+    "system_noise": 0.01,
+    "measurement_noise": 3
   },
   "temper": {
     "enabled": false,

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ var Publisher = require('./components/publisher');
 if (config.get('ble.enabled')) {
     var BLEScanner = require('./components/ble');
 }
+if (config.get('ibeacon.enabled')) {
+    var iBeaconScanner = require('./components/ibeacon');
+}
 if (config.get('temper.enabled')) {
     var Temper = require('./components/temper');
 }
@@ -27,6 +30,9 @@ RoomAssistantApp.prototype._init = function () {
     if (config.get('ble.enabled')) {
         this._setupBLE();
     }
+    if (config.get('ibeacon.enabled')) {
+        this._setupiBeacon();
+    }
     if (config.get('temper.enabled')) {
         this._setupTemper();
     }
@@ -37,6 +43,10 @@ RoomAssistantApp.prototype._init = function () {
 
 RoomAssistantApp.prototype._setupBLE = function () {
     return new BLEScanner(this.publisher.publish.bind(this.publisher));
+};
+
+RoomAssistantApp.prototype._setupiBeacon = function () {
+    return new iBeaconScanner(this.publisher.publish.bind(this.publisher));
 };
 
 RoomAssistantApp.prototype._setupTemper = function () {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "kalmanjs": "^1.0.0-beta",
     "mqtt": "^1.14.0",
     "noble": "^1.6.0",
+    "bleacon": "^0.5.1",
     "scribe-js": "^2.0.4",
     "temper1": "0.0.7",
     "pi-gpio": "^0.0.8"


### PR DESCRIPTION
This component is intended to be specific to only iBeacons instead of all BLE devices to allow for easier whitelisting purposes via UUID-major-minor. I understand there could be some confusion in the overlap of the BLE and iBeacon components but I think they do stand alone due to the UUID-major-minor focus of this vs the BLE modules MAC. BLE still allows the use of other devices such as fitness trackers etc that aren't actual iBeacons.

This is using Bleacon from the same author as Noble for consistency purposes. The scanner does start immediately on init instead of via event though as Bleacon does not have required events at this time like Noble.

Right now the ID is calculated as 'UUID-major-minor' which is probably not ideal but it needed to be more than just the UUID due to overlap. All extra data is coming through for further processing though:

[room_presence]                             {
[room_presence]                               "id": "e2c56db5dffb48d2b060d0f5a71096e1-10-152",
[room_presence]                               "uuid": "e2c56db5dffb48d2b060d0f5a71096e1",
[room_presence]                               "major": 10,
[room_presence]                               "minor": 152,
[room_presence]                               "rssi": -42,
[room_presence]                               "distance": 0.34164432192825195,
[room_presence]                               "measuredpower": -59,
[room_presence]                               "proximity": "immediate"
[room_presence]                             }

The presented distance is the provided 'accuracy' from Bleacon which is not entirely ideal to present this way due to what that value actually means and how much it wavers. Some comparisons via the same distance calculation in the BLE module had it pretty similar. May make this configurable at a later point to have both options.