### PR TITLE
Add masks for major/minor identifiers that vary over time

### DIFF
--- a/components/ble.js
+++ b/components/ble.js
@@ -43,10 +43,17 @@ BLEScanner.prototype._handlePacket = function (peripheral) {
 
     var advertisement = peripheral.advertisement;
 
+    var id;
+    if (config.get('ble.use_mac')) {
+        id = peripheral.address;
+    } else {
+        id = peripheral.id;
+    }
+
     // check if we have a whitelist
     // and if we do, if this id is listed there
     var whitelist = config.get('ble.whitelist') || [];
-    if (whitelist.length == 0 || whitelist.indexOf(peripheral.id) > -1) {
+    if (whitelist.length == 0 || whitelist.indexOf(id) > -1) {
         // default hardcoded value for beacon tx power
         var txPower = advertisement.txPowerLevel || -59;
         var distance = this._calculateDistance(peripheral.rssi, txPower);
@@ -54,14 +61,7 @@ BLEScanner.prototype._handlePacket = function (peripheral) {
         // max distance parameter checking
         var maxDistance = config.get('ble.max_distance') || 0;
         if (maxDistance == 0 || distance <= maxDistance) {
-            var filteredDistance = this._filter(peripheral.id, distance);
-            var id;
-
-            if (config.get('ble.use_mac')) {
-                id = peripheral.address;
-            } else {
-                id = peripheral.id;
-            }
+            var filteredDistance = this._filter(id, distance);
 
             var payload = {
                 id: id,

--- a/components/ibeacon.js
+++ b/components/ibeacon.js
@@ -24,8 +24,10 @@ iBeaconScanner.prototype._handlePacket = function (ibeacon) {
     // check if we have a whitelist
     // and if we do, if this id is listed there
     var whitelist = config.get('ibeacon.whitelist') || [];
+    var major_mask = config.has('ibeacon.major_mask') ? parseInt(config.get('ibeacon.major_mask')) : 0xFFFF;
+    var minor_mask = config.has('ibeacon.minor_mask') ? parseInt(config.get('ibeacon.minor_mask')) : 0xFFFF;
 
-    var id = ibeacon.uuid + '-' + ibeacon.major + '-' + ibeacon.minor;
+    var id = ibeacon.uuid + '-' + (ibeacon.major & major_mask) + '-' + (ibeacon.minor & minor_mask);
 
     if (whitelist.length == 0 || whitelist.indexOf(id) > -1) {
 


### PR DESCRIPTION
Hi, and to start a thanks for this great package that now has my iBeacon streaming into Home Assistant. Magic!

The iBeacon I have multiplexes the Battery Level on to the Minor ID of the device. I think there are a few that are doing (or provide the option) to do this. So I took a steer from the BLE "use_mac" approach to add a similar concept to iBeacons. In this case, I have added "major_mask" and "minor_mask" to allow the end-user to mask out major/minor field bits that may vary over time. In my case, the iBeacon uses the upper two bytes of the minor field to carry 0-100 for the battery level so I want to mask out that portion with 0x00FF as follows:

`  "ibeacon": {
    "enabled": true,
    "minor_mask": "0x00FF",
    "channel": "room_presence",
    "max_distance": 0,
    "whitelist": ["UUID-1-1"],
    "system_noise": 0.01,
    "measurement_noise": 3
  },
`

This gives me a constant device_id to subscribe to with the mqqt_room component in Home Assistant. It also gives me the unadulterated major/minor fields on the channel so that I can extract the battery level on the HA side. Perfect.

Lastly, I moved the "id" modification (use_mac and minor/major_mask) before the whitelist is checked. This way you can use the mac address in the case of BLE or masked major/minor in the case of iBeacons in the whitelist.

Again, this is a great component and many thanks for the efforts. Let me know if any of the above isnt in line with how you want the code and I'll happily modify/alter as needed.