### PR TITLE
Add HASS MQTT auto discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ cache:
   directories:
     - "node_modules"
 
+branches:
+  only:
+  - master
+
 jobs:
   include:
     - stage: lint

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,5 +1,6 @@
 {
   "room": "ROOM",
+  "autoDiscovery": "AUTO_DISCOVERY",
   "mqtt": {
     "url": "MQTT_URL",
     "username": "MQTT_USERNAME",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -27,7 +27,12 @@
     "interval": "D6T_INTERVAL",
     "threshold": "D6T_THRESHOLD",
     "onlyChanges": "D6T_ONLY_CHANGES",
-    "retain": "D6T_RETAIN"
+    "retain": "D6T_RETAIN",
+    "discoveryType": "D6T_DISCOVERY_TYPE",
+    "discoveryConfig": {
+      "__name": "D6T_DISCOVERY_CONFIG",
+      "__format": "json"
+    }
   },
   "gpio": {
     "__name": "GPIO_PINS",

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "services": [],
   "room": "default-room",
+  "autoDiscovery": true,
   "mqtt": {
     "url": "mqtt://localhost",
     "username": "",

--- a/config/default.json
+++ b/config/default.json
@@ -25,7 +25,15 @@
     "interval": 500,
     "threshold": 21,
     "onlyChanges": true,
-    "retain": true
+    "retain": true,
+    "discoveryType": "binary_sensor",
+    "discoveryConfig": {
+      "name": "D6T Default",
+      "payload_on": true,
+      "payload_off": false,
+      "device_class": "motion",
+      "value_template": "{{ value_json.value }}"
+    }
   },
   "gpio": [],
   "shell": [],

--- a/mixins/discovery.mixin.js
+++ b/mixins/discovery.mixin.js
@@ -12,6 +12,9 @@ module.exports = {
                     };
 
                     this.broker.emit('sensor.started', details);
+                })
+                .catch(err => {
+                    this.logger.debug('Could not send auto discovery info, waiting for MQTT service timed out', err);
                 });
         },
 

--- a/mixins/discovery.mixin.js
+++ b/mixins/discovery.mixin.js
@@ -3,7 +3,7 @@
 module.exports = {
     methods: {
         registerSensor(channel, type, config) {
-            this.waitForServices('mqtt', 10 * 1000)
+            this.waitForServices('mqtt', 5 * 1000)
                 .then(() => {
                     const details = {
                         channel: channel,

--- a/mixins/discovery.mixin.js
+++ b/mixins/discovery.mixin.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+    methods: {
+        registerSensor(channel, type, config) {
+            this.waitForServices('mqtt', 10 * 1000)
+                .then(() => {
+                    const details = {
+                        channel: channel,
+                        discoveryType: type,
+                        discoveryConfig: config
+                    };
+
+                    this.broker.emit('sensor.started', details);
+                });
+        },
+
+        unregisterSensor(channel, type) {
+            this.broker.emit('sensor.stopped', { channel, discoveryType: type });
+        }
+    }
+};

--- a/services/d6t.service.js
+++ b/services/d6t.service.js
@@ -3,8 +3,12 @@
 const config = require('config');
 const d6t = require('d6t').d6t;
 
+const DiscoveryService = require('../mixins/discovery.mixin');
+
 module.exports = {
     name: 'd6t',
+
+    mixins: [DiscoveryService],
 
     settings: {
         channel: config.get('d6t.channel'),
@@ -12,7 +16,9 @@ module.exports = {
         interval: config.get('d6t.interval'),
         threshold: config.get('d6t.threshold'),
         onlyChanges: config.get('d6t.onlyChanges'),
-        retain: config.get('d6t.retain')
+        retain: config.get('d6t.retain'),
+        discoveryType: config.get('d6t.discoveryType'),
+        discoveryConfig: config.get('d6t.discoveryConfig')
     },
 
     methods: {
@@ -44,6 +50,8 @@ module.exports = {
     },
 
     async started() {
+        this.registerSensor(this.settings.channel, this.settings.discoveryType, this.settings.discoveryConfig);
+
         const sensorType = d6t[this.settings.type];
         d6t.d6t_open_js(this.d6tDevh, sensorType, null);
 
@@ -54,5 +62,7 @@ module.exports = {
         clearInterval(this.interval);
 
         d6t.d6t_close_js(this.d6tDevh);
+
+        this.unregisterSensor(this.settings.channel, this.settings.discoveryType);
     }
 };

--- a/services/gpio.service.js
+++ b/services/gpio.service.js
@@ -43,7 +43,20 @@ module.exports = {
         });
     },
 
-    stopped() {
+    async started() {
+        this.settings.ports.forEach((port) => {
+            const details = {
+                channel: port.channel,
+                discoverable: true,
+                discoveryType: port.discoveryType,
+                discoveryConfig: port.discoveryConfig
+            };
+
+            this.broker.emit('sensor.started', details);
+        });
+    },
+
+    async stopped() {
         this.gpioMap.forEach(function (gpio) {
             gpio.unexport();
         });

--- a/services/gpio.service.js
+++ b/services/gpio.service.js
@@ -44,16 +44,19 @@ module.exports = {
     },
 
     async started() {
-        this.settings.ports.forEach((port) => {
-            const details = {
-                channel: port.channel,
-                discoverable: true,
-                discoveryType: port.discoveryType,
-                discoveryConfig: port.discoveryConfig
-            };
+        this.waitForServices('mqtt', 10 * 1000)
+            .then(() => {
+                this.settings.ports.forEach((port) => {
+                    const details = {
+                        channel: port.channel,
+                        discoverable: true,
+                        discoveryType: port.discoveryType,
+                        discoveryConfig: port.discoveryConfig
+                    };
 
-            this.broker.emit('sensor.started', details);
-        });
+                    this.broker.emit('sensor.started', details);
+                });
+            });
     },
 
     async stopped() {

--- a/services/gpio.service.js
+++ b/services/gpio.service.js
@@ -3,8 +3,12 @@
 const config = require('config');
 const Gpio = require('onoff').Gpio;
 
+const DiscoveryService = require('../mixins/discovery.mixin');
+
 module.exports = {
     name: 'gpio',
+
+    mixins: [DiscoveryService],
 
     settings: {
         ports: config.get('gpio')
@@ -44,24 +48,18 @@ module.exports = {
     },
 
     async started() {
-        this.waitForServices('mqtt', 10 * 1000)
-            .then(() => {
-                this.settings.ports.forEach((port) => {
-                    const details = {
-                        channel: port.channel,
-                        discoverable: true,
-                        discoveryType: port.discoveryType,
-                        discoveryConfig: port.discoveryConfig
-                    };
-
-                    this.broker.emit('sensor.started', details);
-                });
-            });
+        this.settings.ports.forEach((port) => {
+            this.registerSensor(port.channel, port.discoveryType, port.discoveryConfig);
+        });
     },
 
     async stopped() {
         this.gpioMap.forEach(function (gpio) {
             gpio.unexport();
+        });
+
+        this.settings.ports.forEach((port) => {
+            this.unregisterSensor(port.channel, port.discoveryType);
         });
     }
 };

--- a/services/mqtt.service.js
+++ b/services/mqtt.service.js
@@ -20,12 +20,22 @@ module.exports = {
 
     events: {
         'sensor.started'(details) {
-            if (this.settings.discoveryEnabled && details.discoverable) {
+            if (this.settings.discoveryEnabled) {
                 const baseTopic = `homeassistant/${details.discoveryType}/${this.settings.room}/${details.channel}`;
                 this.channelRegistry[details.channel] = `${baseTopic}/state`;
 
                 this.logger.debug(`Sending discovery info to ${baseTopic}/config`);
                 this.client.publish(`${baseTopic}/config`, JSON.stringify(details.discoveryConfig), { retain: true });
+            }
+        },
+
+        'sensor.stopped'(details) {
+            if (this.settings.discoveryEnabled) {
+                delete this.channelRegistry[details.channel];
+
+                const configTopic = `homeassistant/${details.discoveryType}/${this.settings.room}/${details.channel}`;
+                this.logger.debug(`Removing discovery config from ${configTopic}`);
+                this.client.publish(configTopic, null, { retain: true });
             }
         },
 

--- a/services/mqtt.service.js
+++ b/services/mqtt.service.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const config = require('config');
 const mqtt = require('mqtt');
 
@@ -20,7 +21,7 @@ module.exports = {
 
     events: {
         'sensor.started'(details) {
-            if (this.settings.discoveryEnabled) {
+            if (this.settings.discoveryEnabled && _.isString(details.discoveryType) && _.isObject(details.discoveryConfig)) {
                 const baseTopic = `homeassistant/${details.discoveryType}/${this.settings.room}/${details.channel}`;
                 this.channelRegistry[details.channel] = `${baseTopic}/state`;
 
@@ -30,7 +31,7 @@ module.exports = {
         },
 
         'sensor.stopped'(details) {
-            if (this.settings.discoveryEnabled) {
+            if (this.settings.discoveryEnabled && _.isString(details.discoveryType)) {
                 delete this.channelRegistry[details.channel];
 
                 const configTopic = `homeassistant/${details.discoveryType}/${this.settings.room}/${details.channel}`;

--- a/services/mqtt.service.js
+++ b/services/mqtt.service.js
@@ -24,6 +24,7 @@ module.exports = {
                 const baseTopic = `homeassistant/${details.discoveryType}/${this.settings.room}/${details.channel}`;
                 this.channelRegistry[details.channel] = `${baseTopic}/state`;
 
+                this.logger.debug(`Sending discovery info to ${baseTopic}/config`);
                 this.client.publish(`${baseTopic}/config`, JSON.stringify(details.discoveryConfig), { retain: true });
             }
         },

--- a/services/shell.service.js
+++ b/services/shell.service.js
@@ -6,11 +6,12 @@ const slugify = require('slugify');
 const util = require('util');
 
 const CronService = require('moleculer-cron');
+const DiscoveryService = require('../mixins/discovery.mixin');
 
 module.exports = {
     name: 'shell',
 
-    mixins: [CronService],
+    mixins: [CronService, DiscoveryService],
 
     crons: config.get('shell').map((command) => {
         return {
@@ -81,5 +82,17 @@ module.exports = {
                     });
             }
         }
+    },
+
+    async started() {
+        config.get('shell').forEach((command) => {
+            this.registerSensor(command.channel, command.discoveryType, command.discoveryConfig);
+        });
+    },
+
+    async stopped() {
+        config.get('shell').forEach((command) => {
+            this.unregisterSensor(command.channel, command.discoveryType);
+        });
     }
 };


### PR DESCRIPTION
Home Assistant has [MQTT auto discovery](https://www.home-assistant.io/docs/mqtt/discovery/) for a while now, this makes some of the room assistant sensors compatible. Unfortunately we can't make the ble service work with this yet, as mqtt_room would need to be updated on the Home Assistant side to support the auto discovery.