### PR TITLE
Add whitelist regex and customized measured power to BLE

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -13,6 +13,7 @@
       "__name": "BLE_WHITELIST",
       "__format": "json"
     },
+    "whitelistRegex": "BLE_WHITELIST_REGEX",
     "txPowerOverride": {
       "__name": "BLE_TX_POWER_OVERRIDE",
       "__format": "json"

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -13,6 +13,10 @@
       "__name": "BLE_WHITELIST",
       "__format": "json"
     },
+    "txPowerOverride": {
+      "__name": "BLE_TX_POWER_OVERRIDE",
+      "__format": "json"
+    },
     "maxDistance": "BLE_MAX_DISTANCE",
     "updateFrequency": "BLE_UPDATE_FREQUENCY",
     "processIBeacon": "BLE_PROCESS_IBEACON",

--- a/config/default.json
+++ b/config/default.json
@@ -12,7 +12,7 @@
     "useAddress": false,
     "whitelist": [],
     "whitelistRegex": false,
-    "txPowerOverride": [],
+    "txPowerOverride": {},
     "maxDistance": 0,
     "updateFrequency": 0,
     "processIBeacon": true,

--- a/config/default.json
+++ b/config/default.json
@@ -11,6 +11,7 @@
     "channel": "room_presence",
     "useAddress": false,
     "whitelist": [],
+    "txPowerOverride": [],
     "maxDistance": 0,
     "updateFrequency": 0,
     "processIBeacon": true,

--- a/config/default.json
+++ b/config/default.json
@@ -11,6 +11,7 @@
     "channel": "room_presence",
     "useAddress": false,
     "whitelist": [],
+    "whitelistRegex": false,
     "txPowerOverride": [],
     "maxDistance": 0,
     "updateFrequency": 0,

--- a/mixins/whitelist.mixin.js
+++ b/mixins/whitelist.mixin.js
@@ -2,12 +2,21 @@
 
 module.exports = {
     settings: {
-        whitelist: []
+        whitelist: [],
+        whitelistRegex: false
     },
 
     methods: {
         isOnWhitelist(item) {
-            return this.settings.whitelist.length < 1 || this.settings.whitelist.includes(item);
+            if (this.settings.whitelist.length < 1) {
+                return true;
+            }
+
+            if (this.settings.whitelistRegex) {
+                return this.settings.whitelist.some(regex => item.match(regex));
+            } else {
+                return this.settings.whitelist.includes(item);
+            }
         }
     }
 };

--- a/services/ble.service.js
+++ b/services/ble.service.js
@@ -18,6 +18,7 @@ module.exports = {
 
         channel: config.get('ble.channel'),
         useAddress : config.get('ble.useAddress'),
+        txPowerOverride: config.get('ble.txPowerOverride'),
         maxDistance: config.get('ble.maxDistance'),
         processIBeacon: config.get('ble.processIBeacon'),
         onlyIBeacon: config.get('ble.onlyIBeacon'),
@@ -44,7 +45,11 @@ module.exports = {
             const handle = this.settings.useAddress ? peripheral.address : peripheral.id;
 
             if (this.isOnWhitelist(handle) && !this.isThrottled(handle)) {
-                const power = peripheral.measuredPower || peripheral.advertisement.txPower;
+                let power = peripheral.measuredPower || peripheral.advertisement.txPower;
+                if (this.getConfiguredTxPower(handle) !== null) {
+                    power = this.getConfiguredTxPower(handle);
+                }
+
                 const distance = this.calculateDistance(peripheral.rssi, power);
                 const maxDistance = this.settings.maxDistance;
 
@@ -90,6 +95,10 @@ module.exports = {
             peripheral.id = `${peripheral.uuid}-${peripheral.major & this.settings.majorMask}-${peripheral.minor & this.settings.minorMask}`;
 
             return peripheral;
+        },
+
+        getConfiguredTxPower(id) {
+            return this.settings.txPowerOverride.hasOwnProperty(id) ? this.settings.txPowerOverride[id] : null;
         },
 
         calculateDistance(rssi, txPower) {

--- a/services/ble.service.js
+++ b/services/ble.service.js
@@ -15,6 +15,7 @@ module.exports = {
     settings: {
         frequency: config.get('ble.updateFrequency'),
         whitelist: config.get('ble.whitelist'),
+        whitelistRegex: config.get('ble.whitelistRegex'),
 
         channel: config.get('ble.channel'),
         useAddress : config.get('ble.useAddress'),


### PR DESCRIPTION
This adds new config settings for allowing the whitelist to consist of regex patterns and for overriding the measured power value used for distance calculation per id.

Resolves #58 and #66.