### PR TITLE
Ble tags blackList

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -15,6 +15,11 @@
       "__format": "json"
     },
     "whitelistRegex": "BLE_WHITELIST_REGEX",
+    "blacklist": {
+      "__name": "BLE_BLACKLIST",
+      "__format": "json"
+    },
+    "blacklistRegex": "BLE_BLACKLIST_REGEX",
     "txPowerOverride": {
       "__name": "BLE_TX_POWER_OVERRIDE",
       "__format": "json"

--- a/config/default.json
+++ b/config/default.json
@@ -13,6 +13,8 @@
     "useAddress": false,
     "whitelist": [],
     "whitelistRegex": false,
+    "blacklist": [],
+    "blacklistRegex": false,
     "txPowerOverride": {},
     "maxDistance": 0,
     "updateFrequency": 0,

--- a/mixins/blacklist.mixin.js
+++ b/mixins/blacklist.mixin.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+    settings: {
+        blacklist: [],
+        blacklistRegex: false
+    },
+
+    methods: {
+        isOnBlacklist(item) {
+            if (this.settings.blacklist.length < 1) {
+                return false;
+            }
+
+            if (this.settings.blacklistRegex) {
+                return this.settings.blacklist.some(regex => item.match(regex));
+            } else {
+                return this.settings.blacklist.includes(item);
+            }
+        }
+    }
+};

--- a/services/ble.service.js
+++ b/services/ble.service.js
@@ -18,7 +18,7 @@ module.exports = {
         whitelist: config.get('ble.whitelist'),
         whitelistRegex: config.get('ble.whitelistRegex'),
         blacklist: config.get('ble.blacklist'),
-        blacklistRegex: config.get('ble.blackistRegex'),
+        blacklistRegex: config.get('ble.blacklistRegex'),
 
         channel: config.get('ble.channel'),
         useAddress : config.get('ble.useAddress'),

--- a/services/ble.service.js
+++ b/services/ble.service.js
@@ -6,16 +6,19 @@ const noble = require('@abandonware/noble');
 const KalmanService = require('../mixins/kalman.mixin');
 const ThrottledService = require('../mixins/throttled.mixin');
 const WhitelistService = require('../mixins/whitelist.mixin');
+const BlacklistService = require('../mixins/blacklist.mixin');
 
 module.exports = {
     name: 'ble',
 
-    mixins: [KalmanService, ThrottledService, WhitelistService],
+    mixins: [KalmanService, ThrottledService, WhitelistService, BlacklistService],
 
     settings: {
         frequency: config.get('ble.updateFrequency'),
         whitelist: config.get('ble.whitelist'),
         whitelistRegex: config.get('ble.whitelistRegex'),
+        blacklist: config.get('ble.blacklist'),
+        blacklistRegex: config.get('ble.blackistRegex'),
 
         channel: config.get('ble.channel'),
         useAddress : config.get('ble.useAddress'),
@@ -45,7 +48,7 @@ module.exports = {
 
             const handle = this.settings.useAddress ? peripheral.address : peripheral.id;
 
-            if (this.isOnWhitelist(handle) && !this.isThrottled(handle)) {
+            if (this.isOnWhitelist(handle) && !this.isOnBlacklist(handle) && !this.isThrottled(handle)) {
                 let power = peripheral.measuredPower || peripheral.advertisement.txPower;
                 if (this.getConfiguredTxPower(handle) !== null) {
                     power = this.getConfiguredTxPower(handle);


### PR DESCRIPTION
Hi.
I am using blacklist for tags to filter neighbor ble devices (but i can't use whitelist because i need to add my changed tags to all room-assistant instances - maybe mqtt-whitelist can be added?). So I have implemented simple blacklist here.

Maybe it will be useful for others.