### PR TITLE
Update bluetooth-low-energy.service.ts For ios compatabilty 

### DIFF
--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.ts
@@ -83,7 +83,7 @@ export class BluetoothLowEnergyService extends KalmanFilterable(Object, 0.8, 15)
       this.seenIds.add(tag.id);
     }
 
-    if (this.isOnWhitelist(tag.id)) {
+    if (this.isOnWhitelist(tag.id) || this.isOnWhitelist(tag.name)) {
       tag = this.applyOverrides(tag);
       tag.rssi = this.filterRssi(tag.id, tag.rssi);
 
@@ -106,18 +106,24 @@ export class BluetoothLowEnergyService extends KalmanFilterable(Object, 0.8, 15)
    * @param event - Event with new distance data
    */
   handleNewDistance(event: NewDistanceEvent): void {
-    const sensorId = makeId(`ble ${event.tagId}`);
+    const sensorId = makeId(`ble ${event.tagName}`);
     let sensor: RoomPresenceDistanceSensor;
     if (this.entitiesService.has(sensorId)) {
       sensor = this.entitiesService.get(sensorId) as RoomPresenceDistanceSensor;
     } else {
-      sensor = this.createRoomPresenceSensor(
-        sensorId,
-        event.tagId,
-        event.tagName
-      );
-    }
-
+      if (this.isOnWhitelist(event.tagId)) {
+        sensor = this.createRoomPresenceSensor(
+          sensorId,
+          event.tagId,
+          event.tagName
+        );
+        } else {
+        sensor = this.createRoomPresenceSensor(
+            sensorId,
+            event.tagName,
+            event.tagName
+        );
+      }
     sensor.handleNewDistance(
       event.instanceName,
       event.distance,


### PR DESCRIPTION
Add ability to use BLE device name. with IOS you can change the name with "nRF Connect" app. And it remains changed even after closing the app and locking the phone. You do need to restart the app and advertiser after a reboot of the device. but ill take it i tested for 24 hours and still had it working