### PR TITLE
fix: replace apostrophes with dashes

### DIFF
--- a/src/util/id.spec.ts
+++ b/src/util/id.spec.ts
@@ -14,4 +14,8 @@ describe('makeId', () => {
   it('should convert underscores to dashes', () => {
     expect(makeId('bluetooth-classic_129-1-1')).toMatch(idRegex);
   });
+
+  it('should convert apostrophes to dashes', () => {
+    expect(makeId("parent's-room")).toMatch(idRegex);
+  });
 });

--- a/src/util/id.ts
+++ b/src/util/id.ts
@@ -9,5 +9,5 @@ import slugify from 'slugify';
 export function makeId(input: string): string {
   return slugify(input, {
     lower: true,
-  }).replace(/[_:]/g, '-');
+  }).replace(/[_:']/g, '-');
 }


### PR DESCRIPTION
**Describe the change**
Fixes issue #281 by replacing apostrophes in instance name's with a dash.

**Checklist**
If you changed code:
- [+] Tests run locally and pass (`npm test`)
- [+] Code has correct format (`npm run format`)
   - Files I did not modify were formatted but those are not in this commit.

**Additional information**
This fixes the immediate issue but not sure it's the most thorough fix.