### PR TITLE
Add batteryMask for iBeacons

### DIFF
--- a/docs/integrations/bluetooth-low-energy.md
+++ b/docs/integrations/bluetooth-low-energy.md
@@ -56,6 +56,7 @@ If you are unsure what ID your device has you can start room-assistant with the 
 | `maxDistance`     | Number                          |          | Limits the distance at which a received BLE advertisement is still reported if configured. Value is in meters. |
 | `majorMask`       | Number                          | `0xffff` | Filter out bits of the major ID to make dynamic tag IDs with encoded information consistent for filtering. |
 | `minorMask`       | Number                          | `0xffff` | Filter out bits of the minor ID to make dynamic tag IDs with encoded information consistent for filtering. |
+| `batteryMask`     | Number                          | `0x00000000` | If non-zero, extract the beacon's battery level from the major/minor fields. The mask operates on a 32bit value with major as the high two bytes and minor as the low two bytes. |
 | `tagOverrides`    | [Tag Overrides](#tag-overrides) |          | Allows you to override some properties of the tracked devices. |
 | `hciDeviceId`     | Number                          | `0`      | ID of the Bluetooth device to use for the inquiries, e.g. `0` to use `hci0`. |
 
@@ -67,6 +68,7 @@ The tag overrides object can be considered as a map with the BLE tag ID as key a
 | --------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`          | String |         | Sets a friendly name for the device, which is sent to the home automation software for easier identification.                                                                                                                                                                                                                           |
 | `measuredPower` | Number |         | Overrides the [measured power](https://community.estimote.com/hc/en-us/articles/201636913-What-are-Broadcasting-Power-RSSI-and-other-characteristics-of-a-beacon-s-signal-) of a BLE tag, which is used for distance calculation. Should be the expected RSSI when the beacon is exactly 1 meter away from the room-assistant instance. |
+| `batteryMask`       | Number                          | `0x00000000` | If non-zero, extract the beacon's battery level from the major/minor fields. The mask operates on a 32bit value with major as the high two bytes and minor as the low two bytes. |
 
 ::: details Example Config
 ```yaml
@@ -82,6 +84,7 @@ bluetoothLowEnergy:
     7750fb4dab70:
       name: Cool BLE Tag
       measuredPower: -61
+      batteryMask: 0x0000FF00
 ```
 :::
 

--- a/src/integrations/bluetooth-classic/bluetooth-classic.service.ts
+++ b/src/integrations/bluetooth-classic/bluetooth-classic.service.ts
@@ -28,7 +28,7 @@ import { DISTRIBUTED_DEVICE_ID } from '../home-assistant/home-assistant.const';
 import { Switch } from '../../entities/switch';
 import { SwitchConfig } from '../home-assistant/switch-config';
 import { DeviceTracker } from '../../entities/device-tracker';
-import { RoomPresenceDeviceTrackerProxyHandler } from '../room-presence/room-presence-device-tracker.proxy';
+import { RoomPresenceProxyHandler } from '../room-presence/room-presence.proxy';
 import { BluetoothService } from '../bluetooth/bluetooth.service';
 
 const execPromise = util.promisify(exec);
@@ -355,7 +355,7 @@ export class BluetoothClassicService
     );
     const sensorProxy = new Proxy<RoomPresenceDistanceSensor>(
       rawSensor,
-      new RoomPresenceDeviceTrackerProxyHandler(deviceTracker)
+      new RoomPresenceProxyHandler(deviceTracker)
     );
 
     const sensor = this.entitiesService.add(

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy-presence.sensor.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy-presence.sensor.ts
@@ -12,18 +12,21 @@ class BluetoothLowEnergyMeasurement {
 
 export class BluetoothLowEnergyPresenceSensor extends RoomPresenceDistanceSensor {
   measuredValues: { [instance: string]: BluetoothLowEnergyMeasurement } = {};
+  batteryLevel?: number;
 
   handleNewMeasurement(
     instanceName: string,
     rssi: number,
     measuredPower: number,
     distance: number,
-    outOfRange: boolean
+    outOfRange: boolean,
+    batteryLevel?: number
   ): void {
     this.measuredValues[instanceName] = new BluetoothLowEnergyMeasurement(
       rssi,
       measuredPower
     );
     this.handleNewDistance(instanceName, distance, outOfRange);
+    if (batteryLevel !== undefined) this.batteryLevel = batteryLevel;
   }
 }

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.config.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.config.ts
@@ -8,6 +8,7 @@ export class BluetoothLowEnergyConfig {
   onlyIBeacon = false;
   majorMask = 0xffff;
   minorMask = 0xffff;
+  batteryMask = 0x00000000;
   tagOverrides: { [key: string]: TagOverride } = {};
 
   timeout = 5;
@@ -18,4 +19,5 @@ export class BluetoothLowEnergyConfig {
 class TagOverride {
   name?: string;
   measuredPower?: number;
+  batteryMask?: number;
 }

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.spec.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.spec.ts
@@ -696,13 +696,14 @@ describe('BluetoothLowEnergyService', () => {
     expect(entitiesService.add).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'ble-new',
-        name: 'New Tag Room Presence',
+        name: 'New Tag Room',
         timeout: 20,
       }),
       expect.any(Array)
     );
     expect(entitiesService.add).toHaveBeenCalledWith(
-      new DeviceTracker('ble-new-tracker', 'New Tag', true)
+      new DeviceTracker('ble-new-tracker', 'New Tag Tracker', true),
+      expect.any(Array)
     );
     expect(
       util.types.isProxy(entitiesService.add.mock.calls[1][0])

--- a/src/integrations/bluetooth-low-energy/i-beacon.ts
+++ b/src/integrations/bluetooth-low-energy/i-beacon.ts
@@ -2,27 +2,49 @@ import { Tag } from './tag';
 import { Peripheral } from '@abandonware/noble';
 
 export class IBeacon extends Tag {
-  constructor(peripheral: Peripheral, majorMask = 0xffff, minorMask = 0xffff) {
+  constructor(
+    peripheral: Peripheral,
+    majorMask = 0xffff,
+    minorMask = 0xffff,
+    batteryMask = 0x00000000
+  ) {
     super(peripheral);
     this.uuid = this.peripheral.advertisement.manufacturerData
       .slice(4, 20)
       .toString('hex');
-    this.major =
-      this.peripheral.advertisement.manufacturerData.readUInt16BE(20) &
-      majorMask;
-    this.minor =
-      this.peripheral.advertisement.manufacturerData.readUInt16BE(22) &
-      minorMask;
+    const major = this.peripheral.advertisement.manufacturerData.readUInt16BE(
+      20
+    );
+    const minor = this.peripheral.advertisement.manufacturerData.readUInt16BE(
+      22
+    );
     this.measuredPower = this.peripheral.advertisement.manufacturerData.readInt8(
       24
     );
+
+    this._rawMajorMinor = (major << 16) + minor;
+    this.major = major & majorMask;
+    this.minor = minor & minorMask;
+    this.batteryMask = batteryMask;
   }
 
   uuid: string;
   major: number;
   minor: number;
+  batteryMask: number;
+  private _rawMajorMinor: number;
 
   get id(): string {
     return `${this.uuid}-${this.major}-${this.minor}`;
+  }
+
+  get batteryLevel() {
+    if (!this.batteryMask) {
+      return undefined;
+    }
+
+    const battery = this._rawMajorMinor & this.batteryMask;
+    const offset = Math.log2(this.batteryMask & -this.batteryMask);
+    return battery >> offset;
   }
 }

--- a/src/integrations/bluetooth-low-energy/i-beacon.ts
+++ b/src/integrations/bluetooth-low-energy/i-beacon.ts
@@ -38,7 +38,7 @@ export class IBeacon extends Tag {
     return `${this.uuid}-${this.major}-${this.minor}`;
   }
 
-  get batteryLevel() {
+  get batteryLevel(): number | undefined {
     if (!this.batteryMask) {
       return undefined;
     }

--- a/src/integrations/bluetooth-low-energy/new-distance.event.ts
+++ b/src/integrations/bluetooth-low-energy/new-distance.event.ts
@@ -6,7 +6,8 @@ export class NewDistanceEvent {
     rssi: number,
     measuredPower: number,
     distance: number,
-    outOfRange = false
+    outOfRange = false,
+    batteryLevel?: number
   ) {
     this.instanceName = instanceName;
     this.tagId = tagId;
@@ -15,6 +16,7 @@ export class NewDistanceEvent {
     this.measuredPower = measuredPower;
     this.distance = distance;
     this.outOfRange = outOfRange;
+    this.batteryLevel = batteryLevel;
   }
 
   instanceName: string;
@@ -24,4 +26,5 @@ export class NewDistanceEvent {
   measuredPower: number;
   distance: number;
   outOfRange: boolean;
+  batteryLevel?: number;
 }

--- a/src/integrations/room-presence/room-presence.proxy.spec.ts
+++ b/src/integrations/room-presence/room-presence.proxy.spec.ts
@@ -1,8 +1,8 @@
 import { RoomPresenceDistanceSensor } from './room-presence-distance.sensor';
 import { DeviceTracker } from '../../entities/device-tracker';
-import { RoomPresenceDeviceTrackerProxyHandler } from './room-presence-device-tracker.proxy';
+import { RoomPresenceProxyHandler } from './room-presence.proxy';
 
-describe('RoomPresenceDeviceTrackerProxyHandler', () => {
+describe('RoomPresenceProxyHandler', () => {
   let proxy: RoomPresenceDistanceSensor;
   let deviceTracker: DeviceTracker;
 
@@ -16,7 +16,7 @@ describe('RoomPresenceDeviceTrackerProxyHandler', () => {
     );
     proxy = new Proxy<RoomPresenceDistanceSensor>(
       sensor,
-      new RoomPresenceDeviceTrackerProxyHandler(deviceTracker)
+      new RoomPresenceProxyHandler(deviceTracker)
     );
   });
 

--- a/src/integrations/room-presence/room-presence.proxy.spec.ts
+++ b/src/integrations/room-presence/room-presence.proxy.spec.ts
@@ -1,19 +1,19 @@
 import { RoomPresenceDistanceSensor } from './room-presence-distance.sensor';
 import { DeviceTracker } from '../../entities/device-tracker';
+import { Sensor } from '../../entities/sensor';
 import { RoomPresenceProxyHandler } from './room-presence.proxy';
 
 describe('RoomPresenceProxyHandler', () => {
   let proxy: RoomPresenceDistanceSensor;
   let deviceTracker: DeviceTracker;
+  let batterySensor: Sensor;
+  let sensor: RoomPresenceDistanceSensor;
 
   beforeEach(() => {
     deviceTracker = new DeviceTracker('test-tracker', 'Test Tracker');
+    batterySensor = new Sensor('test-battery', 'Test Battery');
 
-    const sensor = new RoomPresenceDistanceSensor(
-      'test-sensor',
-      'Test Sensor',
-      0
-    );
+    sensor = new RoomPresenceDistanceSensor('test-sensor', 'Test Sensor', 0);
     proxy = new Proxy<RoomPresenceDistanceSensor>(
       sensor,
       new RoomPresenceProxyHandler(deviceTracker)
@@ -30,5 +30,16 @@ describe('RoomPresenceProxyHandler', () => {
     proxy.updateState();
 
     expect(deviceTracker.state).toBeFalsy();
+  });
+
+  it('should set the battery level to value', () => {
+    const sensorProxy = new Proxy<RoomPresenceDistanceSensor>(
+      sensor,
+      new RoomPresenceProxyHandler(deviceTracker, batterySensor)
+    );
+
+    sensorProxy['batteryLevel'] = 99;
+
+    expect(batterySensor.state).toBe(99);
   });
 });

--- a/src/integrations/room-presence/room-presence.proxy.ts
+++ b/src/integrations/room-presence/room-presence.proxy.ts
@@ -9,18 +9,20 @@ export class RoomPresenceProxyHandler
   implements ProxyHandler<RoomPresenceDistanceSensor> {
   constructor(
     private readonly deviceTracker: DeviceTracker,
-    private readonly batterySensor: Sensor = undefined
+    private readonly batterySensor?: Sensor
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   set(target: RoomPresenceDistanceSensor, p: PropertyKey, value: any): boolean {
     target[p] = value;
 
-    if (p === 'state') {
-      this.deviceTracker.state = value != STATE_NOT_HOME;
-    }
-    if (p === 'batteryLevel') {
-      this.batterySensor.state = value;
+    switch (p) {
+      case 'state':
+        this.deviceTracker.state = value != STATE_NOT_HOME;
+        break;
+      case 'batteryLevel':
+        this.batterySensor.state = value;
+        break;
     }
 
     return true;

--- a/src/integrations/room-presence/room-presence.proxy.ts
+++ b/src/integrations/room-presence/room-presence.proxy.ts
@@ -3,10 +3,14 @@ import {
   STATE_NOT_HOME,
 } from './room-presence-distance.sensor';
 import { DeviceTracker } from '../../entities/device-tracker';
+import { Sensor } from '../../entities/sensor';
 
-export class RoomPresenceDeviceTrackerProxyHandler
+export class RoomPresenceProxyHandler
   implements ProxyHandler<RoomPresenceDistanceSensor> {
-  constructor(private readonly deviceTracker: DeviceTracker) {}
+  constructor(
+    private readonly deviceTracker: DeviceTracker,
+    private readonly batterySensor: Sensor = undefined
+  ) {}
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   set(target: RoomPresenceDistanceSensor, p: PropertyKey, value: any): boolean {
@@ -14,6 +18,9 @@ export class RoomPresenceDeviceTrackerProxyHandler
 
     if (p === 'state') {
       this.deviceTracker.state = value != STATE_NOT_HOME;
+    }
+    if (p === 'batteryLevel') {
+      this.batterySensor.state = value;
     }
 
     return true;


### PR DESCRIPTION
**Describe the change**
Some iBeacons provide battery level information in the major/minor fields. This PR adds a `batteryMask` option to identify the battery level and, if present, create a new sensor entity so that the information can be sent to, for example, Home Assistant. The mask operates on a 32bit field using `major` as the high two bytes and `minor` as the low two bytes.

So, for example, with some Jaylee beacons that provide 0-100 value in the high byte of the minor field, you can use `batteryMask: "0x0000FF00"` to extract the information. You can add the option at the BLE module or beacon level (via tagOverride).

Let me know if this is useful and I can adjust docs/test as needed.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.js` and `docs/integrations/README.md`

**Additional information**
Partially addresses #160 
