### PR TITLE
add instance name to attributes

### DIFF
--- a/src/integrations/bluetooth-classic/bluetooth-classic.service.spec.ts
+++ b/src/integrations/bluetooth-classic/bluetooth-classic.service.spec.ts
@@ -483,6 +483,7 @@ describe('BluetoothClassicService', () => {
     sensor.distances['test-instance'] = {
       distance: 10,
       outOfRange: false,
+      instanceName: 'bt-test',
       lastUpdatedAt: new Date(),
     };
     const device = { address: 'test', name: 'Test' };
@@ -521,6 +522,7 @@ describe('BluetoothClassicService', () => {
     sensor.distances = {};
     sensor.distances['test-instance'] = {
       distance: 10,
+      instanceName: 'bt-test',
       outOfRange: false,
       lastUpdatedAt: new Date(Date.now() - 25 * 1000),
     };

--- a/src/integrations/room-presence/room-presence-distance.sensor.ts
+++ b/src/integrations/room-presence/room-presence-distance.sensor.ts
@@ -6,9 +6,11 @@ class TimedDistance {
   distance: number;
   outOfRange: boolean;
   lastUpdatedAt: Date = new Date();
+  instanceName: string;
 
-  constructor(distance: number, outOfRange = false) {
+  constructor(distance: number, instanceName: string, outOfRange = false) {
     this.distance = distance;
+    this.instanceName = instanceName;
     this.outOfRange = outOfRange;
   }
 }
@@ -34,7 +36,7 @@ export class RoomPresenceDistanceSensor extends Sensor {
     distance: number,
     outOfRange = false
   ): void {
-    this.distances[instanceName] = new TimedDistance(distance, outOfRange);
+    this.distances[instanceName] = new TimedDistance(distance, instanceName, outOfRange);
     this.updateState();
   }
 
@@ -52,6 +54,7 @@ export class RoomPresenceDistanceSensor extends Sensor {
       if (this.state === closestInRange[0]) {
         this.attributes.distance = closestInRange[1].distance;
         this.attributes.lastUpdatedAt = closestInRange[1].lastUpdatedAt.toISOString();
+        this.attributes.instanceName = closestInRange[1].instanceName;
       }
     } else if (this.state !== STATE_NOT_HOME) {
       this.setNotHome();


### PR DESCRIPTION
**Describe the change**
A clear and concise description of what you changed.
I use nodered to subscribe to mqtt messages. I can subscribe the the ble device's state channel to get which instance the device is near OR i can subscribe to the attributes channel and get the distance and last updated. I cannot know the distance AND the instance in the same channel. This adds the `instanceName` to the attributes so I can know both values on the same subscription.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.js` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?
