### PR TITLE
Template sensors

### DIFF
--- a/src/config/definitions/default.ts
+++ b/src/config/definitions/default.ts
@@ -2,6 +2,7 @@ import { BluetoothLowEnergyConfig } from '../../integrations/bluetooth-low-energ
 import { ClusterConfig } from '../../cluster/cluster.config';
 import { GlobalConfig } from '../global.config';
 import { HomeAssistantConfig } from '../../integrations/home-assistant/home-assistant.config';
+import { AdTemplateConfig } from '../../integrations/ad-template/ad-template.config';
 import { OmronD6tConfig } from '../../integrations/omron-d6t/omron-d6t.config';
 import { GridEyeConfig } from '../../integrations/grid-eye/grid-eye.config';
 import { BluetoothClassicConfig } from '../../integrations/bluetooth-classic/bluetooth-classic.config';
@@ -16,6 +17,7 @@ export class AppConfig {
   entities: EntitiesConfig = new EntitiesConfig();
   bluetoothLowEnergy: BluetoothLowEnergyConfig = new BluetoothLowEnergyConfig();
   bluetoothClassic: BluetoothClassicConfig = new BluetoothClassicConfig();
+  adTemplate: AdTemplateConfig = new AdTemplateConfig();
   omronD6t: OmronD6tConfig = new OmronD6tConfig();
   gridEye: GridEyeConfig = new GridEyeConfig();
   gpio: GpioConfig = new GpioConfig();

--- a/src/integrations/ad-template/ad-template.config.ts
+++ b/src/integrations/ad-template/ad-template.config.ts
@@ -1,0 +1,18 @@
+export class AdTemplateConfig {
+  devices: AdTemplateDeviceOptions[] = [];
+}
+
+export class AdTemplateDeviceOptions {
+  address: string;
+  name: string;
+  helpers: string[];
+  sensors: AdTemplateSensorOptions[];
+}
+
+export class AdTemplateSensorOptions {
+  name: string;
+  state: string;
+  deviceClass?: string;
+  unitOfMeasurement?: string;
+  icon?: string;
+}

--- a/src/integrations/ad-template/ad-template.module.ts
+++ b/src/integrations/ad-template/ad-template.module.ts
@@ -1,0 +1,17 @@
+import './env';
+import { DynamicModule, Module } from '@nestjs/common';
+import { AdTemplateService } from './ad-template.service';
+import { EntitiesModule } from '../../entities/entities.module';
+import { ConfigModule } from '../../config/config.module';
+import { BluetoothModule } from '../bluetooth/bluetooth.module';
+
+@Module({})
+export default class AdTemplateModule {
+  static forRoot(): DynamicModule {
+    return {
+      module: AdTemplateModule,
+      imports: [BluetoothModule, EntitiesModule, ConfigModule],
+      providers: [AdTemplateService],
+    };
+  }
+}

--- a/src/integrations/ad-template/ad-template.service.ts
+++ b/src/integrations/ad-template/ad-template.service.ts
@@ -1,0 +1,192 @@
+import {
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  OnModuleInit,
+} from '@nestjs/common';
+import * as mathjs from 'mathjs';
+import { Peripheral } from '@abandonware/noble';
+import { EntitiesService } from '../../entities/entities.service';
+import { ConfigService } from '../../config/config.service';
+import {
+  AdTemplateConfig,
+  AdTemplateDeviceOptions,
+  AdTemplateSensorOptions,
+} from './ad-template.config';
+import { DISTRIBUTED_DEVICE_ID } from '../home-assistant/home-assistant.const';
+import { makeId } from '../../util/id';
+import { Sensor } from '../../entities/sensor';
+import { EntityCustomization } from '../../entities/entity-customization.interface';
+import { SensorConfig } from '../home-assistant/sensor-config';
+import { BluetoothService } from '../bluetooth/bluetooth.service';
+
+interface templateScope {
+  id: string;
+  uuid: string;
+  address: string;
+  addressType: string;
+  connectable: boolean;
+  rssi: number;
+  state:
+    | 'error'
+    | 'connecting'
+    | 'connected'
+    | 'disconnecting'
+    | 'disconnected';
+  localName: string;
+  serviceDataUuid: string[];
+  serviceData: number[][];
+  txPowerLevel: number;
+  manufacturerData: number[];
+  serviceUuids: string[];
+}
+
+interface templateHelper {
+  config: string;
+  code: mathjs.EvalFunction;
+}
+
+interface templateSensor {
+  config: AdTemplateSensorOptions;
+  code: mathjs.EvalFunction;
+}
+
+@Injectable()
+export class AdTemplateService implements OnModuleInit, OnApplicationBootstrap {
+  private config: AdTemplateConfig;
+  private helpers: templateHelper[] = [];
+  private sensors: templateSensor[] = [];
+  private readonly logger: Logger;
+
+  constructor(
+    private readonly bluetoothService: BluetoothService,
+    private readonly entitiesService: EntitiesService,
+    private readonly configService: ConfigService
+  ) {
+    this.logger = new Logger(AdTemplateService.name);
+    this.config = this.configService.get('adTemplate');
+    this.config.devices.forEach((device) => {
+      this.helpers[device.address] = [];
+      this.sensors[device.address] = [];
+      device.helpers?.forEach((helper) => {
+        this.helpers[device.address].push({
+          config: helper,
+          code: mathjs.compile(helper),
+        });
+      });
+      device.sensors?.forEach((sensor) => {
+        this.sensors[device.address].push({
+          config: sensor,
+          code: mathjs.compile(sensor.state),
+        });
+      });
+    });
+  }
+
+  /**
+   * Lifecycle hook, called once the host module has been initialized.
+   */
+  onModuleInit(): void {
+    if (this.config.devices.length == 0) {
+      this.logger.warn(
+        'No device entries in the config, so no sensors will be created!'
+      );
+    }
+  }
+
+  /**
+   * Lifecycle hook, called once the application has started.
+   */
+  onApplicationBootstrap(): void {
+    this.bluetoothService.onLowEnergyDiscovery(this.handleDiscovery.bind(this));
+  }
+
+  /**
+   * Filters found BLE peripherals and publishes new readings to sensors, depending on configuration.
+   *
+   * @param peripheral - BLE peripheral
+   */
+  handleDiscovery(peripheral: Peripheral): void {
+    const { advertisement, id } = peripheral || {};
+    const device = this.config.devices.find((i) => i.address === id);
+    if (!device) {
+      return;
+    }
+
+    const scope: templateScope = {
+      id: id,
+      uuid: peripheral.uuid,
+      address: peripheral.address,
+      addressType: peripheral.addressType,
+      connectable: peripheral.connectable,
+      rssi: peripheral.rssi,
+      state: peripheral.state,
+      localName: advertisement.localName,
+      serviceDataUuid: advertisement.serviceData.map((entry) => entry.uuid),
+      serviceData: advertisement.serviceData.map((entry) => [...entry.data]),
+      txPowerLevel: advertisement.txPowerLevel,
+      manufacturerData: [...(advertisement.manufacturerData ?? [])],
+      serviceUuids: [...(advertisement.serviceUuids ?? [])],
+    };
+
+    // Add helpers into the template's evaluation scope
+    this.helpers[id].forEach((helper: templateHelper) => {
+      try {
+        helper.code.evaluate(scope);
+      } catch (error) {
+        this.logger.error(
+          `${device.name} failed to evaluate \"${helper.config}\" - ${error}`
+        );
+        return;
+      }
+    });
+
+    this.sensors[id].forEach((sensor: templateSensor) => {
+      let value;
+      try {
+        value = sensor.code.evaluate(scope);
+      } catch (error) {
+        this.logger.error(
+          `${device.name} failed to evaluate \"${sensor.config.state}\" - ${error}`
+        );
+        return;
+      }
+
+      if (value === null) return;
+
+      this.publishSensor(device, sensor.config, value);
+    });
+  }
+
+  publishSensor(
+    device: AdTemplateDeviceOptions,
+    sensor: AdTemplateSensorOptions,
+    state: number
+  ): void {
+    const unique_id = makeId(`AdTemplate ${device.address} ${sensor.name}`);
+    let entity = this.entitiesService.get(unique_id);
+    if (!entity) {
+      const customizations: Array<EntityCustomization<any>> = [
+        {
+          for: SensorConfig,
+          overrides: {
+            deviceClass: sensor.deviceClass,
+            unitOfMeasurement: sensor.unitOfMeasurement,
+            icon: sensor.icon,
+            device: {
+              identifiers: device.address,
+              name: device.name,
+              viaDevice: DISTRIBUTED_DEVICE_ID,
+            },
+          },
+        },
+      ];
+      entity = this.entitiesService.add(
+        new Sensor(unique_id, `${device.name} ${sensor.name}`, true),
+        customizations
+      ) as Sensor;
+    }
+    entity.state = state;
+    this.logger.log(`${device.name} ${sensor.name}: ${state}`);
+  }
+}

--- a/src/integrations/ad-template/env.ts
+++ b/src/integrations/ad-template/env.ts
@@ -1,0 +1,3 @@
+import c from 'config';
+
+process.env.NOBLE_HCI_DEVICE_ID = c.get('adTemplate.hciDeviceId');


### PR DESCRIPTION
**Describe the change**
I have been using [MathJS](https://mathjs.org/) to provide syntax/evaluation of template sensors using Advertisement data. Not sure if this is of interest as it is more "ble gateway" than "room presence" but thought I would share. Its still a bit rough but if useful then happy to adapt/tighten/add tests etc.

MathJS seemed best fit given bit/byte operators and support for helpers/custom functions. But it does have a few quirks. Arrays are represented as matricies with indexing 1 based e.g. `serviceData[1, 2]` instead of `serviceData[0][1]`.  Unfortunately, there is no short-circuiting of logical operators hence the need for nested ternaries in MiFlora template below.

My main use-case for this was miflora devices which has reduced now with the introduction of the xiaomi service. But the examples below provide a sense of the capability and should be transferable to other ble devices.

Example config.yml
```yaml
adTemplate:
  hciDeviceId: 0
  devices:
    - address: f6ef6ba03231
      name: iBeacon
      sensors:
        - name: Battery
          state: "manufacturerData[26]"
          deviceClass: "battery"
          unitOfMeasurement: "%"
    - address: a4c138cb1d6f
      name: Xiaomi (ATC)
      sensors:
        - name: Temperature
          state: "((serviceData[1, 11] << 8) + serviceData[1, 12]) / 10"
          deviceClass: "temperature"
          unitOfMeasurement: "°C"
    - address: c47c8d6bb35b
      name: MiFlora
      helpers:
        - "data = squeeze(row(serviceData, 1))"
        - "isEvent = (data[1] & 64) > 0"
        - "isEventType(type) = isEvent ? (data[14] << 8) + data[13] == type : false"
      sensors:
        - name: Temperature
          state: "isEventType(4100) ? ((data[17] << 8) + data[16]) / 10 : null"
          deviceClass: "temperature"
          unitOfMeasurement: "°C"
        - name: Moisture
          state: "isEventType(4104) ? data[16] : null"
          deviceClass: "battery"
          unitOfMeasurement: "%"
```

**Checklist**
If you changed code:
- [ ] Tests run locally and pass (`npm test`)
- [ ] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.js` and `docs/integrations/README.md`

**Additional information**