### PR TITLE
Align device_tracker discovery between BLE and BT Classic

### DIFF
--- a/src/integrations/bluetooth-classic/bluetooth-classic.service.spec.ts
+++ b/src/integrations/bluetooth-classic/bluetooth-classic.service.spec.ts
@@ -30,6 +30,7 @@ import c from 'config';
 import { ConfigService } from '../../config/config.service';
 import { Device } from './device';
 import { DeviceTracker } from '../../entities/device-tracker';
+import { DeviceTrackerConfig } from '../home-assistant/device-tracker-config';
 import * as util from 'util';
 
 jest.mock('mdns', () => ({}), { virtual: true });
@@ -407,7 +408,7 @@ describe('BluetoothClassicService', () => {
     expect(handleRssiMock).not.toHaveBeenCalled();
   });
 
-  it('should register a new sensor for a previously unknown device', async () => {
+  it('should register a new sensor and device tracker for a previously unknown device', async () => {
     entitiesService.has.mockReturnValue(false);
     entitiesService.add.mockImplementation((entity) => entity);
     clusterService.nodes.mockReturnValue({
@@ -429,9 +430,24 @@ describe('BluetoothClassicService', () => {
     expect(entitiesService.add).toHaveBeenCalledWith(
       new DeviceTracker(
         'bluetooth-classic-10-36-cf-ca-9a-18-tracker',
-        'Test Device',
+        'Test Device Tracker',
         true
-      )
+      ),
+      [
+        {
+          for: DeviceTrackerConfig,
+          overrides: {
+            sourceType: 'bluetooth',
+            device: {
+              identifiers: '10:36:cf:ca:9a:18',
+              name: 'Test Device',
+              connections: [['mac', '10:36:cf:ca:9a:18']],
+              manufacturer: undefined,
+              viaDevice: 'room-assistant-distributed',
+            },
+          },
+        },
+      ]
     );
     expect(entitiesService.add).toHaveBeenCalledWith(
       expect.any(RoomPresenceDistanceSensor),

--- a/src/integrations/bluetooth-classic/bluetooth-classic.service.ts
+++ b/src/integrations/bluetooth-classic/bluetooth-classic.service.ts
@@ -26,19 +26,12 @@ import { KalmanFilterable } from '../../util/filters';
 import { makeId } from '../../util/id';
 import { Device } from './device';
 import { DISTRIBUTED_DEVICE_ID } from '../home-assistant/home-assistant.const';
+import { Device as DeviceInfo } from '../home-assistant/device';
 import { Switch } from '../../entities/switch';
 import { SwitchConfig } from '../home-assistant/switch-config';
 import { DeviceTracker } from '../../entities/device-tracker';
 import { RoomPresenceProxyHandler } from '../room-presence/room-presence.proxy';
 import { BluetoothService } from '../bluetooth/bluetooth.service';
-
-interface DeviceInfo {
-  identifiers: string | string[];
-  name: string;
-  manufacturer?: string;
-  connections?: string[][];
-  viaDevice?: string;
-}
 
 const execPromise = util.promisify(exec);
 


### PR DESCRIPTION
**Describe the change**
Align device_tracker discovery for BT Classic integration. Happy to adjust as needed.

Note: I dont have any BT Classic devices to test this against. I have adapted jest test to validate device_tracker discovery logic.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.js` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?
See #488 for details.