### PR TITLE
Discovery prefix

### DIFF
--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -23,6 +23,7 @@ room-assistant makes use of the [MQTT auto discovery](https://www.home-assistant
 | `mqttUrl`        | String                        | `mqtt://localhost:1883` | Connection string for your MQTT broker.                      |
 | `mqttOptions`    | [MQTT Options](#mqtt-options) |                         | Additional options for the MQTT connection.                  |
 | `sendAttributes` | Boolean                       | `true`                  | Whether entity attributes should be forwarded to Home Assistant or not. May be disabled to reduce the number of messages that Home Assistant needs to process. |
+| `discoveryPrefix`| String                        | `homeassistant`         | The prefix for the discovery topic that Home Assistant will watch. |
 
 ### MQTT Options
 
@@ -43,6 +44,7 @@ homeAssistant:
   mqttOptions:
     username: youruser
     password: yourpass
+  discoveryPrefix: homeassistant
 ```
 
 :::

--- a/src/integrations/home-assistant/entity-config.ts
+++ b/src/integrations/home-assistant/entity-config.ts
@@ -25,7 +25,7 @@ export abstract class EntityConfig {
     this.device = device;
 
     this.uniqueId = `room-assistant-${id}`;
-    this.configTopic = `homeassistant/${this.component}/room-assistant/${id}/config`;
+    this.configTopic = `${this.component}/room-assistant/${id}/config`;
     this.stateTopic = `room-assistant/${this.component}/${id}/state`;
     this.jsonAttributesTopic = `room-assistant/${this.component}/${id}/attributes`;
     this.availabilityTopic = `room-assistant/${this.component}/${id}/status`;

--- a/src/integrations/home-assistant/home-assistant.config.ts
+++ b/src/integrations/home-assistant/home-assistant.config.ts
@@ -4,4 +4,5 @@ export class HomeAssistantConfig {
   mqttUrl = 'mqtt://localhost:1883';
   mqttOptions: IClientOptions = {};
   sendAttributes = true;
+  discoveryPrefix = 'homeassistant';
 }

--- a/src/integrations/home-assistant/home-assistant.service.ts
+++ b/src/integrations/home-assistant/home-assistant.service.ts
@@ -140,10 +140,14 @@ export class HomeAssistantService
       config instanceof CameraConfig ? _.omit(config, ['stateTopic']) : config
     );
 
+    // concatenate discoveryPrefix to configTopic
+    const discoveryTopic =
+      this.config.discoveryPrefix + '/' + config.configTopic;
+
     this.logger.debug(
-      `Registering entity ${config.uniqueId} under ${config.configTopic}`
+      `Registering entity ${config.uniqueId} under ${discoveryTopic}`
     );
-    this.mqttClient.publish(config.configTopic, JSON.stringify(message), {
+    this.mqttClient.publish(discoveryTopic, JSON.stringify(message), {
       qos: 0,
       retain: true,
     });


### PR DESCRIPTION
**Describe the change**
Added the configuration option for the MQTT discoveryPrefix for the homeAssistant integration.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [x] Documentation page added in `docs/integrations/` (Documentation updated)
- [ ] Page linked in `docs/.vuepress/config.js` and `docs/integrations/README.md` (N/A)

**Additional information**
First time working with TypeScript, so let me know if I need to fix anything.