### PR TITLE
Miflora batteries

### DIFF
--- a/src/config/config.service.spec.fail.yml
+++ b/src/config/config.service.spec.fail.yml
@@ -176,6 +176,7 @@ shell:
           offCommand: echo off
 xiaomiMi:
   hciDeviceId: 0
+  enableMifloraBattery: 5              # FORMAT ERROR: -> Bool Required
   sensors:
     - address: a4:c1:38:32:12:f9       # FORMAT ERROR: -> Hex Required / Length Exceeded Errors
       name: Xiaomi 1

--- a/src/config/config.service.spec.pass.yml
+++ b/src/config/config.service.spec.pass.yml
@@ -167,9 +167,11 @@ shell:
       offCommand: echo off
 xiaomiMi:
   hciDeviceId: 0
+  enableMifloraBattery: false
   sensors:
     - address: a4c1383212f9
       name: Xiaomi 1
+      enableMifloraBattery: true
     - address: a4c138131f9e
       name: Xiaomi 2
       bindKey: 2456789ABCDEF

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -99,6 +99,7 @@ describe('ConfigService', () => {
       `gpio.binarySensors[1].deviceClass`,
       `shell.sensors[1].switches`,
       `shell.switches`,
+      `xiaomiMi.enableMifloraBattery`,
       `xiaomiMi.sensors[0].address`,
       `xiaomiMi.sensors[0].address`,
       `homeAssistant.discoveryPrefix`,

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.spec.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.spec.ts
@@ -40,9 +40,7 @@ describe('BluetoothLowEnergyService', () => {
     lowEnergyAdapterId: 0,
     lowEnergyScanUptime: 16 * 1000,
     onLowEnergyDiscovery: jest.fn(),
-    connectLowEnergyDevice: jest.fn(),
-    disconnectLowEnergyDevice: jest.fn(),
-    resetHciDevice: jest.fn(),
+    queryLowEnergyDevice: jest.fn(),
   };
   const clusterService = {
     on: jest.fn(),
@@ -1054,7 +1052,6 @@ describe('BluetoothLowEnergyService', () => {
         .mockImplementation(() => undefined);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      const discoverSpy = jest.spyOn(service, 'discoverCompanionAppId');
 
       await service.handleDiscovery({
         id: 'abcd1234',
@@ -1067,7 +1064,7 @@ describe('BluetoothLowEnergyService', () => {
         },
       } as Peripheral);
 
-      expect(discoverSpy).not.toHaveBeenCalled();
+      expect(bluetoothService.queryLowEnergyDevice).not.toHaveBeenCalled();
     });
 
     it('should ignore non-connectable advertisements', async () => {
@@ -1076,7 +1073,6 @@ describe('BluetoothLowEnergyService', () => {
         .mockImplementation(() => undefined);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      const discoverSpy = jest.spyOn(service, 'discoverCompanionAppId');
 
       await service.handleDiscovery({
         id: 'abcd1234',
@@ -1089,7 +1085,7 @@ describe('BluetoothLowEnergyService', () => {
         },
       } as Peripheral);
 
-      expect(discoverSpy).not.toHaveBeenCalled();
+      expect(bluetoothService.queryLowEnergyDevice).not.toHaveBeenCalled();
     });
 
     it('should ignore advertisements from devices without overflow area', async () => {
@@ -1098,7 +1094,6 @@ describe('BluetoothLowEnergyService', () => {
         .mockImplementation(() => undefined);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      const discoverSpy = jest.spyOn(service, 'discoverCompanionAppId');
 
       await service.handleDiscovery({
         id: 'abcd1234',
@@ -1111,7 +1106,7 @@ describe('BluetoothLowEnergyService', () => {
         },
       } as Peripheral);
 
-      expect(discoverSpy).not.toHaveBeenCalled();
+      expect(bluetoothService.queryLowEnergyDevice).not.toHaveBeenCalled();
     });
 
     it('should ignore advertisements from devices that do not advertise the right service in the overflow area', async () => {
@@ -1120,7 +1115,6 @@ describe('BluetoothLowEnergyService', () => {
         .mockImplementation(() => undefined);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      const discoverSpy = jest.spyOn(service, 'discoverCompanionAppId');
       const manufacturerData = Buffer.from(APPLE_MANUFACTURER_DATA);
       manufacturerData.set([0x01], 6);
 
@@ -1135,7 +1129,7 @@ describe('BluetoothLowEnergyService', () => {
         },
       } as Peripheral);
 
-      expect(discoverSpy).not.toHaveBeenCalled();
+      expect(bluetoothService.queryLowEnergyDevice).not.toHaveBeenCalled();
     });
 
     it('should override tag ids with companion app IDs', async () => {
@@ -1144,7 +1138,9 @@ describe('BluetoothLowEnergyService', () => {
         .mockImplementation(() => undefined);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      jest.spyOn(service, 'discoverCompanionAppId').mockResolvedValue('app-id');
+      bluetoothService.queryLowEnergyDevice.mockResolvedValue(
+        Buffer.from('app-id', 'utf-8')
+      );
 
       await service.handleDiscovery({
         id: 'abcd1234',
@@ -1176,7 +1172,7 @@ describe('BluetoothLowEnergyService', () => {
         .mockImplementation(() => undefined);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      jest.spyOn(service, 'discoverCompanionAppId').mockResolvedValue(null);
+      bluetoothService.queryLowEnergyDevice.mockResolvedValue(null);
 
       await service.handleDiscovery({
         id: 'abcd1234',
@@ -1208,9 +1204,9 @@ describe('BluetoothLowEnergyService', () => {
         .mockImplementation(() => undefined);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      const discoverSpy = jest
-        .spyOn(service, 'discoverCompanionAppId')
-        .mockResolvedValue('app-id');
+      bluetoothService.queryLowEnergyDevice.mockResolvedValue(
+        Buffer.from('app-id', 'utf-8')
+      );
 
       const peripheral = {
         id: 'abcd1234',
@@ -1226,7 +1222,7 @@ describe('BluetoothLowEnergyService', () => {
       await service.handleDiscovery(peripheral);
       await service.handleDiscovery(peripheral);
 
-      expect(discoverSpy).toHaveBeenCalledTimes(1);
+      expect(bluetoothService.queryLowEnergyDevice).toHaveBeenCalledTimes(1);
     });
 
     it('should publish discovered companion app IDs to the cluster', async () => {
@@ -1235,7 +1231,9 @@ describe('BluetoothLowEnergyService', () => {
         .mockImplementation(() => undefined);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      jest.spyOn(service, 'discoverCompanionAppId').mockResolvedValue('app-id');
+      bluetoothService.queryLowEnergyDevice.mockResolvedValue(
+        Buffer.from('app-id', 'utf-8')
+      );
 
       await service.handleDiscovery({
         id: 'abcd1234',
@@ -1264,7 +1262,6 @@ describe('BluetoothLowEnergyService', () => {
       entitiesService.get.mockReturnValue(sensor);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      const discoverSpy = jest.spyOn(service, 'discoverCompanionAppId');
 
       await service.handleNewDistance(
         new NewDistanceEvent(
@@ -1290,7 +1287,7 @@ describe('BluetoothLowEnergyService', () => {
         },
       } as Peripheral);
 
-      expect(discoverSpy).not.toHaveBeenCalled();
+      expect(bluetoothService.queryLowEnergyDevice).not.toHaveBeenCalled();
       expect(newDistanceSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           peripheralId: 'peripheral-id',
@@ -1306,9 +1303,9 @@ describe('BluetoothLowEnergyService', () => {
         .mockImplementation(() => undefined);
       jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
       jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-      const discoverSpy = jest
-        .spyOn(service, 'discoverCompanionAppId')
-        .mockRejectedValue(new Error('expected for this test'));
+      bluetoothService.queryLowEnergyDevice.mockRejectedValue(
+        new Error('expected for this test')
+      );
 
       const peripheral = {
         id: 'abcd1234',
@@ -1324,239 +1321,13 @@ describe('BluetoothLowEnergyService', () => {
       await service.handleDiscovery(peripheral);
       await service.handleDiscovery(peripheral);
 
-      expect(discoverSpy).toHaveBeenCalledTimes(1);
+      expect(bluetoothService.queryLowEnergyDevice).toHaveBeenCalledTimes(1);
 
       jest.advanceTimersByTime(60 * 1000);
 
       await service.handleDiscovery(peripheral);
 
-      expect(discoverSpy).toHaveBeenCalledTimes(2);
-    });
-
-    it('should reset the adapter when discovery attempts time out', async () => {
-      jest
-        .spyOn(service, 'handleNewDistance')
-        .mockImplementation(() => undefined);
-      jest.spyOn(service, 'isAllowlistEnabled').mockReturnValue(true);
-      jest.spyOn(service, 'isOnAllowlist').mockReturnValue(true);
-
-      const peripheral = {
-        id: 'abcd1234',
-        rssi: -50,
-        connectable: true,
-        discoverServicesAsync: jest
-          .fn()
-          .mockRejectedValue(new Error('timed out')),
-        once: jest.fn(),
-        advertisement: {
-          localName: 'Test Beacon',
-          txPowerLevel: -72,
-          manufacturerData: APPLE_MANUFACTURER_DATA,
-        },
-      } as unknown as Peripheral;
-      bluetoothService.connectLowEnergyDevice.mockResolvedValue(peripheral);
-
-      await service.handleDiscovery(peripheral);
-
-      expect(bluetoothService.resetHciDevice).toHaveBeenCalledWith(
-        bluetoothService.lowEnergyAdapterId
-      );
-    });
-
-    it('should discover the companion app ID from the well known characteristic', async () => {
-      const gattCharacteristic = {
-        readAsync: jest.fn().mockResolvedValue(Buffer.from('app-id', 'utf-8')),
-      };
-      const gattService = {
-        discoverCharacteristicsAsync: jest
-          .fn()
-          .mockResolvedValue([gattCharacteristic]),
-      };
-      const peripheral = {
-        id: 'abcd1234',
-        rssi: -50,
-        connectable: true,
-        advertisement: {
-          localName: 'Test Beacon',
-          txPowerLevel: -72,
-          manufacturerData: APPLE_MANUFACTURER_DATA,
-        },
-        discoverServicesAsync: jest.fn().mockResolvedValue([gattService]),
-        once: jest.fn(),
-        removeListener: jest.fn(),
-      } as unknown as Peripheral;
-
-      bluetoothService.connectLowEnergyDevice.mockResolvedValue(peripheral);
-
-      const actual = await service.discoverCompanionAppId(new Tag(peripheral));
-
-      expect(actual).toBe('app-id');
-    });
-
-    it('should return null if device does not have characteristic', async () => {
-      const gattService = {
-        discoverCharacteristicsAsync: jest.fn().mockResolvedValue([]),
-      };
-      const peripheral = {
-        id: 'abcd1234',
-        rssi: -50,
-        connectable: true,
-        advertisement: {
-          localName: 'Test Beacon',
-          txPowerLevel: -72,
-          manufacturerData: APPLE_MANUFACTURER_DATA,
-        },
-        discoverServicesAsync: jest.fn().mockResolvedValue([gattService]),
-        removeListener: jest.fn(),
-        once: jest.fn(),
-      } as unknown as Peripheral;
-
-      bluetoothService.connectLowEnergyDevice.mockResolvedValue(peripheral);
-
-      const actual = await service.discoverCompanionAppId(new Tag(peripheral));
-
-      expect(actual).toBeNull();
-    });
-
-    it('should return null if device does not have service', async () => {
-      const peripheral = {
-        id: 'abcd1234',
-        rssi: -50,
-        connectable: true,
-        advertisement: {
-          localName: 'Test Beacon',
-          txPowerLevel: -72,
-          manufacturerData: APPLE_MANUFACTURER_DATA,
-        },
-        discoverServicesAsync: jest.fn().mockResolvedValue([]),
-        removeListener: jest.fn(),
-        once: jest.fn(),
-      } as unknown as Peripheral;
-
-      bluetoothService.connectLowEnergyDevice.mockResolvedValue(peripheral);
-
-      const actual = await service.discoverCompanionAppId(new Tag(peripheral));
-
-      expect(actual).toBeNull();
-    });
-
-    it('should return null if there is an error while discovering GATT information', async () => {
-      const gattService = {
-        discoverCharacteristicsAsync: jest
-          .fn()
-          .mockRejectedValue(new Error('expected for this test')),
-      };
-      const peripheral = {
-        id: 'abcd1234',
-        rssi: -50,
-        connectable: true,
-        advertisement: {
-          localName: 'Test Beacon',
-          txPowerLevel: -72,
-          manufacturerData: APPLE_MANUFACTURER_DATA,
-        },
-        discoverServicesAsync: jest.fn().mockResolvedValue([gattService]),
-        removeListener: jest.fn(),
-        once: jest.fn(),
-      } as unknown as Peripheral;
-
-      bluetoothService.connectLowEnergyDevice.mockResolvedValue(peripheral);
-
-      const actual = await service.discoverCompanionAppId(new Tag(peripheral));
-
-      expect(actual).toBeNull();
-    });
-
-    it('should disconnect from the peripheral after a successful discovery', async () => {
-      const gattCharacteristic = {
-        readAsync: jest.fn().mockResolvedValue(Buffer.from('app-id', 'utf-8')),
-      };
-      const gattService = {
-        discoverCharacteristicsAsync: jest
-          .fn()
-          .mockResolvedValue([gattCharacteristic]),
-      };
-      const peripheral = {
-        id: 'abcd1234',
-        rssi: -50,
-        connectable: true,
-        advertisement: {
-          localName: 'Test Beacon',
-          txPowerLevel: -72,
-          manufacturerData: APPLE_MANUFACTURER_DATA,
-        },
-        discoverServicesAsync: jest.fn().mockResolvedValue([gattService]),
-        removeListener: jest.fn(),
-        once: jest.fn(),
-      } as unknown as Peripheral;
-
-      bluetoothService.connectLowEnergyDevice.mockResolvedValue(peripheral);
-
-      await service.discoverCompanionAppId(new Tag(peripheral));
-
-      expect(bluetoothService.disconnectLowEnergyDevice).toHaveBeenCalledWith(
-        peripheral
-      );
-    });
-
-    it('should disconnect from the peripheral after a failed discovery', async () => {
-      const gattService = {
-        discoverCharacteristicsAsync: jest
-          .fn()
-          .mockRejectedValue(new Error('expected for this test')),
-      };
-      const peripheral = {
-        id: 'abcd1234',
-        rssi: -50,
-        connectable: true,
-        advertisement: {
-          localName: 'Test Beacon',
-          txPowerLevel: -72,
-          manufacturerData: APPLE_MANUFACTURER_DATA,
-        },
-        discoverServicesAsync: jest.fn().mockResolvedValue([gattService]),
-        removeListener: jest.fn(),
-        once: jest.fn(),
-      } as unknown as Peripheral;
-
-      bluetoothService.connectLowEnergyDevice.mockResolvedValue(peripheral);
-
-      await service.discoverCompanionAppId(new Tag(peripheral));
-
-      expect(bluetoothService.disconnectLowEnergyDevice).toHaveBeenCalledWith(
-        peripheral
-      );
-    });
-
-    it('should not disconnect from an already disconnecting peripheral', async () => {
-      const gattCharacteristic = {
-        readAsync: jest.fn().mockResolvedValue(Buffer.from('app-id', 'utf-8')),
-      };
-      const gattService = {
-        discoverCharacteristicsAsync: jest
-          .fn()
-          .mockResolvedValue([gattCharacteristic]),
-      };
-      const peripheral = {
-        id: 'abcd1234',
-        rssi: -50,
-        connectable: true,
-        advertisement: {
-          localName: 'Test Beacon',
-          txPowerLevel: -72,
-          manufacturerData: APPLE_MANUFACTURER_DATA,
-        },
-        discoverServicesAsync: jest.fn().mockResolvedValue([gattService]),
-        removeListener: jest.fn(),
-        once: jest.fn(),
-        state: 'disconnecting',
-      } as unknown as Peripheral;
-
-      bluetoothService.connectLowEnergyDevice.mockResolvedValue(peripheral);
-
-      await service.discoverCompanionAppId(new Tag(peripheral));
-
-      expect(bluetoothService.disconnectLowEnergyDevice).not.toHaveBeenCalled();
+      expect(bluetoothService.queryLowEnergyDevice).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/integrations/xiaomi-mi/xiaomi-mi.config.ts
+++ b/src/integrations/xiaomi-mi/xiaomi-mi.config.ts
@@ -7,6 +7,8 @@ export class XiaomiMiSensorOptions {
   address: string;
   @(jf.string().hex().optional())
   bindKey?: string;
+  @(jf.boolean().optional())
+  enableMifloraBattery?: boolean;
 }
 
 export class XiaomiMiConfig {
@@ -14,4 +16,6 @@ export class XiaomiMiConfig {
   hciDeviceId = 0;
   @(jf.array({ elementClass: XiaomiMiSensorOptions }).required())
   sensors: XiaomiMiSensorOptions[] = [];
+  @(jf.boolean().required())
+  enableMifloraBattery = false;
 }

--- a/src/integrations/xiaomi-mi/xiaomi-mi.service.spec.ts
+++ b/src/integrations/xiaomi-mi/xiaomi-mi.service.spec.ts
@@ -12,11 +12,13 @@ import { SensorConfig } from '../home-assistant/sensor-config';
 import c from 'config';
 import { BluetoothService } from '../../integration-support/bluetooth/bluetooth.service';
 import { BluetoothModule } from '../../integration-support/bluetooth/bluetooth.module';
+import { Parser } from './parser';
 
 describe('XiaomiMiService', () => {
   let service: XiaomiMiService;
   const bluetoothService = {
     onLowEnergyDiscovery: jest.fn(),
+    queryLowEnergyDevice: jest.fn(),
   };
   const entitiesService = {
     get: jest.fn(),
@@ -60,15 +62,17 @@ describe('XiaomiMiService', () => {
     illuminance: '71209800a764aed0a8654c0d0710030e0000',
     fertility: '71209800a564aed0a8654c0d091002b800',
     encrypted: '58585b05db184bf838c1a472c3fa42cd050000ce7b8a28',
+    mifloraFert1: '712098000164aed0a8654c0d091002b800',
+    mifloraFert2: '712098000264aed0a8654c0d091002b800',
   };
   const bindKey = 'b2d46f0cd168c18b247c0c79e9ad5b8d';
   const deviceInfo = {
     identifiers: '4c65a8d0ae64',
     manufacturer: 'Xiaomi',
     name: 'test',
-    swVersion: '2',
     viaDevice: 'room-assistant-distributed',
   };
+  const FRAME_COUNTER_INDEX = 4;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -105,7 +109,12 @@ describe('XiaomiMiService', () => {
 
     mockConfig.sensors = [];
     service.onModuleInit();
-    expect(loggerService.warn).toHaveBeenCalled();
+    expect(loggerService.warn).toHaveBeenCalledTimes(1);
+    expect(loggerService.warn).toHaveBeenCalledWith(
+      expect.stringContaining('No sensors entries in the config'),
+      'XiaomiMiService',
+      false
+    );
   });
 
   it('should not publish from unknown devices', () => {
@@ -116,7 +125,22 @@ describe('XiaomiMiService', () => {
     expect(entitiesService.add).not.toHaveBeenCalled();
   });
 
-  it('should warn if device not Xiaomi', () => {
+  it('should warn if message parser is incorrectly initialised', () => {
+    expect(() => {
+      new Parser(null);
+    }).toThrow('A buffer must be provided.');
+  });
+
+  it('should not publish if missing service data in advertisement', () => {
+    service.handleDiscovery({
+      id: testAddress,
+      advertisement: {},
+    } as Peripheral);
+    expect(entitiesService.get).not.toHaveBeenCalled();
+    expect(entitiesService.add).not.toHaveBeenCalled();
+  });
+
+  it('should not publish if service data in advertisement is not Xiaomi', () => {
     service.handleDiscovery({
       id: testAddress,
       advertisement: {
@@ -128,7 +152,8 @@ describe('XiaomiMiService', () => {
         ],
       },
     } as Peripheral);
-    expect(loggerService.warn).toHaveBeenCalled();
+    expect(entitiesService.get).not.toHaveBeenCalled();
+    expect(entitiesService.add).not.toHaveBeenCalled();
   });
 
   it('should publish temperature', () => {
@@ -298,7 +323,7 @@ describe('XiaomiMiService', () => {
     expect(entitiesService.add).not.toHaveBeenCalled();
   });
 
-  it('should ignore advertisements with no event', () => {
+  it('should not publish when advertisements with no event', () => {
     service.handleDiscovery(advert(testAddress, '30585b05a064aed0a8654c08'));
 
     expect(entitiesService.add).not.toHaveBeenCalled();
@@ -322,33 +347,56 @@ describe('XiaomiMiService', () => {
     expect(sensor.state).toBe(43.9);
   });
 
-  it('should warn on missing bindKey for encrypted payloads', () => {
+  it('should not publish on missing bindKey for encrypted payloads', () => {
     service.handleDiscovery(advert(testAddress, serviceData.encrypted));
 
     expect(entitiesService.get).not.toHaveBeenCalled();
-    expect(loggerService.error).toHaveBeenCalled();
+    expect(loggerService.error).toHaveBeenCalledTimes(1);
+    expect(loggerService.error).toHaveBeenCalledWith(
+      expect.stringContaining('Please configure a bindKey'),
+      '',
+      'XiaomiMiService'
+    );
   });
 
-  it('should report an error on short advertisements', () => {
+  it('should not publish on short advertisements', () => {
     service.handleDiscovery(advert(testAddress, '5020'));
-    expect(loggerService.error).toHaveBeenCalled();
+    expect(entitiesService.get).not.toHaveBeenCalled();
+    expect(loggerService.error).toHaveBeenCalledTimes(1);
+    expect(loggerService.error).toHaveBeenCalledWith(
+      expect.stringContaining('Service data length must be >= 5 bytes'),
+      '',
+      'XiaomiMiService'
+    );
   });
 
-  it('should warn on empty buffers', () => {
+  it('should not publish on empty buffers', () => {
     service.handleDiscovery({
       id: testAddress,
       advertisement: {
         serviceData: [{ uuid: 'fe95', data: null }],
       },
     } as Peripheral);
-    expect(loggerService.warn).toHaveBeenCalled();
+    expect(entitiesService.get).not.toHaveBeenCalled();
+    expect(loggerService.debug).toHaveBeenCalled();
+    expect(loggerService.debug).toHaveBeenCalledWith(
+      expect.stringContaining('supported data format not present'),
+      'XiaomiMiService',
+      false
+    );
   });
 
-  it('should report an error on invalid event types', () => {
+  it('should not publish on invalid event types', () => {
     service.handleDiscovery(
       advert(testAddress, '5020aa014e64aed0a8654c0a11015d')
     );
+    expect(entitiesService.get).not.toHaveBeenCalled();
     expect(loggerService.error).toHaveBeenCalled();
+    expect(loggerService.error).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown event type'),
+      '',
+      'XiaomiMiService'
+    );
   });
 
   it('should publish negative temperatures', () => {
@@ -358,5 +406,158 @@ describe('XiaomiMiService', () => {
       advert(testAddress, serviceData.negativeTemperature)
     );
     expect(sensor.state).toBe(-12.3);
+  });
+
+  it('should process repreated advertisements with different frame counters', async () => {
+    const sensor = new Sensor('testid', 'Test', true, false);
+    entitiesService.add.mockReturnValue(sensor);
+
+    service.handleDiscovery(advert(testAddress, serviceData.mifloraFert1));
+    service.handleDiscovery(advert(testAddress, serviceData.mifloraFert2));
+    expect(entitiesService.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('should ignore repreated advertisements with the same frame counter', async () => {
+    service.handleDiscovery(advert(testAddress, serviceData.mifloraFert1));
+    service.handleDiscovery(advert(testAddress, serviceData.mifloraFert1));
+    expect(entitiesService.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('should poll battery for miflora sensors if global MiFlora Battery config enabled', async () => {
+    const batteryCheckSpy = jest.spyOn(service, 'checkMifloraBattery');
+
+    mockConfig.enableMifloraBattery = false;
+    await service.handleDiscovery(
+      advert(testAddress, serviceData.mifloraFert1)
+    );
+    expect(batteryCheckSpy).not.toHaveBeenCalled();
+
+    mockConfig.enableMifloraBattery = true;
+    await service.handleDiscovery(
+      advert(testAddress, serviceData.mifloraFert2)
+    );
+    expect(batteryCheckSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should overide global MiFlora Battery config with local config if available', async () => {
+    const batteryCheckSpy = jest.spyOn(service, 'checkMifloraBattery');
+
+    mockConfig.enableMifloraBattery = false;
+    mockConfig.sensors[0].enableMifloraBattery = true;
+    await service.handleDiscovery(
+      advert(testAddress, serviceData.mifloraFert1)
+    );
+    expect(batteryCheckSpy).toHaveBeenCalledTimes(1);
+
+    mockConfig.enableMifloraBattery = true;
+    mockConfig.sensors[0].enableMifloraBattery = false;
+    await service.handleDiscovery(
+      advert(testAddress, serviceData.mifloraFert2)
+    );
+    expect(batteryCheckSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should refresh battery within one hour of start-up', async () => {
+    jest.useFakeTimers();
+
+    const fertSensor = new Sensor('fertid', 'Fert', true, false);
+    const battSensor = new Sensor('battid', 'batt', true, false);
+
+    mockConfig.enableMifloraBattery = true;
+    entitiesService.get
+      .mockReturnValueOnce(fertSensor)
+      .mockReturnValueOnce(fertSensor)
+      .mockReturnValueOnce(battSensor);
+    bluetoothService.queryLowEnergyDevice.mockResolvedValue(Buffer.from([42]));
+
+    await service.handleDiscovery(
+      advert(testAddress, serviceData.mifloraFert1)
+    );
+    expect(bluetoothService.queryLowEnergyDevice).not.toBeCalled();
+    expect(entitiesService.get).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(60 * 60 * 1000);
+
+    await service.handleDiscovery(
+      advert(testAddress, serviceData.mifloraFert2)
+    );
+    expect(bluetoothService.queryLowEnergyDevice).toHaveBeenCalledTimes(1);
+    expect(entitiesService.get).toHaveBeenCalledTimes(3);
+    expect(battSensor.state).toBe(42);
+  });
+
+  it('should refresh battery approximately every 24 hours following start-up period', async () => {
+    jest.useFakeTimers();
+
+    mockConfig.enableMifloraBattery = true;
+    const target = advert(testAddress, serviceData.mifloraFert1);
+
+    for (let i = 0; i < 24; i++) {
+      await service.handleDiscovery(target);
+      jest.advanceTimersByTime(1 * 60 * 60 * 1000);
+      target.advertisement.serviceData[0].data[FRAME_COUNTER_INDEX]++;
+    }
+    expect(bluetoothService.queryLowEnergyDevice).toHaveBeenCalledTimes(1);
+
+    // Allow two hours to cover start-up period (+1h) and variable window (+1h)
+    jest.advanceTimersByTime(2 * 60 * 60 * 1000);
+    target.advertisement.serviceData[0].data[FRAME_COUNTER_INDEX]++;
+
+    await service.handleDiscovery(target);
+    expect(bluetoothService.queryLowEnergyDevice).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not publish battery sensor when BLE battery query fails', async () => {
+    jest.useFakeTimers();
+
+    mockConfig.enableMifloraBattery = true;
+
+    await service.handleDiscovery(
+      advert(testAddress, serviceData.mifloraFert1)
+    );
+    expect(entitiesService.get).toHaveBeenCalledTimes(1);
+    expect(bluetoothService.queryLowEnergyDevice).not.toBeCalled();
+    expect(loggerService.warn).not.toHaveBeenCalled();
+
+    bluetoothService.queryLowEnergyDevice.mockRejectedValueOnce(
+      new Error('Aborted Query')
+    );
+    jest.advanceTimersByTime(60 * 60 * 1000);
+
+    await service.handleDiscovery(
+      advert(testAddress, serviceData.mifloraFert2)
+    );
+    expect(bluetoothService.queryLowEnergyDevice).toHaveBeenCalledTimes(1);
+    expect(entitiesService.get).toHaveBeenCalledTimes(2); // +1 for the fertility sensor but not battery
+    expect(loggerService.warn).toHaveBeenCalledTimes(1);
+    expect(loggerService.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Error reading battery level'),
+      'XiaomiMiService',
+      false
+    );
+  });
+
+  it('should retry battery query up to three times before aborting', async () => {
+    jest.useFakeTimers();
+
+    mockConfig.enableMifloraBattery = true;
+    bluetoothService.queryLowEnergyDevice.mockResolvedValue(null);
+
+    const target = advert(testAddress, serviceData.mifloraFert1);
+
+    await service.handleDiscovery(target);
+    expect(bluetoothService.queryLowEnergyDevice).not.toBeCalled();
+
+    jest.advanceTimersByTime(1 * 60 * 60 * 1000);
+
+    for (let i = 1; i < 4; i++) {
+      target.advertisement.serviceData[0].data[FRAME_COUNTER_INDEX]++;
+      await service.handleDiscovery(target);
+      expect(bluetoothService.queryLowEnergyDevice).toHaveBeenCalledTimes(i);
+    }
+
+    target.advertisement.serviceData[0].data[FRAME_COUNTER_INDEX]++;
+    await service.handleDiscovery(target);
+    expect(bluetoothService.queryLowEnergyDevice).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/integrations/xiaomi-mi/xiaomi-mi.service.ts
+++ b/src/integrations/xiaomi-mi/xiaomi-mi.service.ts
@@ -308,7 +308,7 @@ export class XiaomiMiService implements OnModuleInit, OnApplicationBootstrap {
 
     const schedule: BatterySchedule = this.batterySchedule[peripheral.id];
     if (Date.now() > schedule.nextQueryAfter.getTime()) {
-      let buffer: Buffer;
+      let buffer: Buffer = null;
 
       schedule.attempts += 1;
       try {
@@ -317,6 +317,9 @@ export class XiaomiMiService implements OnModuleInit, OnApplicationBootstrap {
           SERVICE_BATTERY_UUID,
           CHARACTERISTIC_BATTERY_UUID
         );
+        if (!buffer) {
+          throw new Error('data unavailable');
+        }
       } catch (error) {
         this.logger.warn(
           `${device.name}: Error reading battery level (attempt ${schedule.attempts} of ${BATTERY_QUERY_ATTEMPTS}): ${error}`
@@ -340,7 +343,7 @@ export class XiaomiMiService implements OnModuleInit, OnApplicationBootstrap {
         );
       }
 
-      if (buffer || schedule.attempts == BATTERY_QUERY_ATTEMPTS) {
+      if (buffer || schedule.attempts >= BATTERY_QUERY_ATTEMPTS) {
         schedule.nextQueryAfter = new Date(
           Date.now() +
             BATTERY_QUERY_INTERVAL +

--- a/src/integrations/xiaomi-mi/xiaomi-mi.service.ts
+++ b/src/integrations/xiaomi-mi/xiaomi-mi.service.ts
@@ -324,6 +324,12 @@ export class XiaomiMiService implements OnModuleInit, OnApplicationBootstrap {
       }
 
       if (buffer) {
+        // buffer[0] -> battery level (0-100)
+        // buffer[2:] -> device firmware version (e.g. "3.2.4")
+        if (buffer.length > 2) {
+          device.swVersion = buffer.toString('utf-8', 2);
+        }
+
         this.recordMeasure(
           device,
           SensorMetadataList[EventType.battery],


### PR DESCRIPTION
**Describe the change**
Adds support for miflora battery sensors. Queries the BLE Service/Characteristic as the information is not provided by advertisement.

There are four commits that cover:
1) Tweaks to existing xiaomi integration: a) extend use of typing; b) simplify handling of sensor events; c) deduping advertisements using frame count; d) detuning some logging to avoid spam
2) Extract BLE query routines from BLE integration and make available as Bluetooth support routines
3) Add polling of the battery service/characteristic on a daily basis (enabled/disabled via config)
4) Re-aligned and added tests for new functionality

The above required changing xiaomi `handleDiscovery()` to be async along the same lines as the BLE integration. Reviewing the existing code suggests this is OK but let me know any concerns. I tried not to change any of the BLE query logic in the process other than moving it from BluetoothLowEnergy to BluetoothService integration. 

I'm doing some more soak testing as BLE queries don't seem quite as stable as advertisements. So marked this as WIP but appreciate any thoughts and happy to adapt. Documentation to follow.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?

Closes #638
