### PR TITLE
Reduce "Discovered new BLE peripheral..." log entries

### DIFF
--- a/docs/integrations/bluetooth-low-energy.md
+++ b/docs/integrations/bluetooth-low-energy.md
@@ -91,6 +91,7 @@ bluetoothLowEnergy:
 | `instanceBeaconEnabled` | Boolean | `true` | Whether this instance should emit iBeacon advertisements via BLE, which can be used by the room-assistant companion app to auto-toggle advertising. |
 | `instanceBeaconMajor` | Number | `1` | The major of the advertised iBeacon. |
 | `instanceBeaconMinor` | Number | Random | The minor of the advertised iBeacon. |
+| `minDiscoveryLogRssi` | Number | -999 | Only log newly discovered beacons if raw RSSI values are grerater than this (usefull to reduce log spam if on a busy street). |
 
 ### Tag Overrides
 

--- a/docs/integrations/bluetooth-low-energy.md
+++ b/docs/integrations/bluetooth-low-energy.md
@@ -91,7 +91,7 @@ bluetoothLowEnergy:
 | `instanceBeaconEnabled` | Boolean | `true` | Whether this instance should emit iBeacon advertisements via BLE, which can be used by the room-assistant companion app to auto-toggle advertising. |
 | `instanceBeaconMajor` | Number | `1` | The major of the advertised iBeacon. |
 | `instanceBeaconMinor` | Number | Random | The minor of the advertised iBeacon. |
-| `minDiscoveryLogRssi` | Number | -999 | Only log newly discovered beacons if raw RSSI values are grerater than this (usefull to reduce log spam if on a busy street). |
+| `minDiscoveryLogRssi` | Number | -999 | Only log newly discovered beacons if raw RSSI values are greater than this (useful to reduce log spam if on a busy street). |
 
 ### Tag Overrides
 

--- a/src/config/config.service.spec.fail.yml
+++ b/src/config/config.service.spec.fail.yml
@@ -96,6 +96,7 @@ bluetoothLowEnergy:
   timeout: 30
   updateFrequence: 55                 # FORMAT ERROR: Key Misspelt
 #  updateFrequency: 55                # FORMAT ERROR: Missing Key
+  minDiscoveryLogRssi: 50             # FORMAT ERROR: Negative Required
   maxDistance: 44.4
   rssiFactor: 1.1
   tagOverrides:

--- a/src/config/config.service.spec.pass.yml
+++ b/src/config/config.service.spec.pass.yml
@@ -91,6 +91,7 @@ bluetoothLowEnergy:
   instanceBeaconMinor: 555
   timeout: 30
   updateFrequency: 55
+  minDiscoveryLogRssi: -60
   maxDistance: 44.4
   rssiFactor: 1.1
   tagOverrides:

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -87,6 +87,7 @@ describe('ConfigService', () => {
       `bluetoothLowEnergy.tagOverrides.ebef1234567890-55555-444.timeout`,
       `bluetoothLowEnergy.updateFrequency`,
       `bluetoothLowEnergy.updateFrequence`,
+      `bluetoothLowEnergy.minDiscoveryLogRssi`,
       `bluetoothClassic.addresses[1]`,
       `bluetoothClassic.addresses[2]`,
       `bluetoothClassic.addresses[3]`,

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.config.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.config.ts
@@ -58,6 +58,8 @@ export class BluetoothLowEnergyConfig {
   rssiFactor = 1;
   @(jf.number().positive().optional())
   maxDistance?: number;
+  @(jf.number().max(0).required())
+  minDiscoveryLogRssi = -999;
 }
 
 function validateTagOverrides(options: {

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.spec.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.spec.ts
@@ -1005,6 +1005,7 @@ describe('BluetoothLowEnergyService', () => {
 
   it('should log the id of new peripherals that are found', async () => {
     mockConfig.processIBeacon = true;
+    mockConfig.minDiscoveryLogRssi = -99;
     jest.spyOn(service, 'isOnAllowlist').mockReturnValue(false);
 
     await service.handleDiscovery({
@@ -1028,8 +1029,18 @@ describe('BluetoothLowEnergyService', () => {
         manufacturerData: iBeaconData,
       },
     } as Peripheral);
+    await service.handleDiscovery({
+      id: 'test-peripheral-99',
+      rssi: -99,
+      advertisement: {},
+    } as Peripheral);
+    await service.handleDiscovery({
+      id: 'test-peripheral-100',
+      rssi: -100,
+      advertisement: {},
+    } as Peripheral);
 
-    expect(loggerService.log).toHaveBeenCalledTimes(2);
+    expect(loggerService.log).toHaveBeenCalledTimes(3);
     expect(loggerService.log).toHaveBeenCalledWith(
       expect.stringContaining('2f234454cf6d4a0fadf2f4911ba9ffa6-1-2'),
       BluetoothLowEnergyService.name,
@@ -1037,6 +1048,11 @@ describe('BluetoothLowEnergyService', () => {
     );
     expect(loggerService.log).toHaveBeenCalledWith(
       expect.stringContaining('test-peripheral-456'),
+      BluetoothLowEnergyService.name,
+      expect.anything()
+    );
+    expect(loggerService.log).toHaveBeenCalledWith(
+      expect.stringContaining('test-peripheral-99'),
       BluetoothLowEnergyService.name,
       expect.anything()
     );

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.ts
@@ -41,7 +41,7 @@ export class BluetoothLowEnergyService
 {
   private readonly config: BluetoothLowEnergyConfig;
   private readonly logger: Logger;
-  private readonly seenIds = new Set<string>();
+  private readonly loggedIds = new Set<string>();
   private readonly companionAppTags = new Map<string, string>();
   private readonly companionAppDenylist = new Set<string>();
   private tagUpdaters: {
@@ -96,11 +96,14 @@ export class BluetoothLowEnergyService
 
     tag = await this.applyCompanionAppOverride(tag);
 
-    if (!this.seenIds.has(tag.id)) {
+    if (
+      !this.loggedIds.has(tag.id) &&
+      tag.rssi >= this.config.minDiscoveryLogRssi
+    ) {
       this.logger.log(
-        `Discovered new BLE peripheral ${tag.name} with ID ${tag.id} and RSSI ${tag.rssi}`
+        `Discovered nearby BLE peripheral ${tag.name} with ID ${tag.id} and RSSI ${tag.rssi}`
       );
-      this.seenIds.add(tag.id);
+      this.loggedIds.add(tag.id);
     }
 
     if (


### PR DESCRIPTION
**Describe the change**
Filter "Discovered new BLE peripheral..." log entries based on rssi value. Allows filtering out those more distant devices that you pick up if living on a busy street. Set `minDiscoveryLogRssi` to, say, -80 for nearby devices.  Only impacts logging.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?
