### PR TITLE
Improve resilience of BLE Inquiry mode

### DIFF
--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -112,7 +112,7 @@ describe('ConfigService', () => {
     errorPaths.forEach((path) =>
       expect(loggerService.error).toHaveBeenCalledWith(
         expect.stringContaining(path),
-        'ConfigService'
+        ConfigService.name
       )
     );
   });

--- a/src/integration-support/bluetooth/bluetooth.service.spec.ts
+++ b/src/integration-support/bluetooth/bluetooth.service.spec.ts
@@ -438,6 +438,33 @@ Requesting information ...
       return promise;
     });
 
+    it('should unlock the adapter following connection time-out', () => {
+      expect.assertions(1);
+      jest.useFakeTimers('modern');
+      const unlockSpy = jest.spyOn(service, 'unlockAdapter');
+
+      const peripheral = {
+        connectable: true,
+        connectAsync: jest
+          .fn()
+          .mockReturnValue(
+            new Promise((resolve) => setTimeout(resolve, 11 * 1000))
+          ),
+        disconnect: jest.fn(),
+        removeAllListeners: jest.fn(),
+        once: jest.fn(),
+      };
+
+      const promise = service
+        .connectLowEnergyDevice(peripheral as unknown as Peripheral)
+        .catch(() => {
+          expect(unlockSpy).toHaveBeenCalledTimes(1);
+        });
+      jest.advanceTimersByTime(10.5 * 1000);
+
+      return promise;
+    });
+
     it('should return the peripheral after connecting', async () => {
       jest.spyOn(Promises, 'sleep').mockResolvedValue();
       const peripheral = {

--- a/src/integration-support/bluetooth/bluetooth.service.spec.ts
+++ b/src/integration-support/bluetooth/bluetooth.service.spec.ts
@@ -632,17 +632,19 @@ Requesting information ...
         CHARACTERISTIC_UUID
       );
 
+      expect(loggerService.error).toHaveBeenCalledTimes(1);
       expect(loggerService.error).toHaveBeenCalledWith(
         expect.stringContaining(
           'Permission to query abcd1234 has not been acquired'
         ),
-        '',
-        'BluetoothService'
+        BluetoothService.name
       );
       expect(response).toBeNull();
 
       service.acquireQueryMutex();
       service.releaseQueryMutex();
+
+      jest.clearAllMocks();
 
       response = await service.queryLowEnergyDevice(
         peripheral,
@@ -650,12 +652,12 @@ Requesting information ...
         CHARACTERISTIC_UUID
       );
 
+      expect(loggerService.error).toHaveBeenCalledTimes(1);
       expect(loggerService.error).toHaveBeenCalledWith(
         expect.stringContaining(
           'Permission to query abcd1234 has not been acquired'
         ),
-        '',
-        'BluetoothService'
+        BluetoothService.name
       );
       expect(response).toBeNull();
     });

--- a/src/integration-support/bluetooth/bluetooth.service.spec.ts
+++ b/src/integration-support/bluetooth/bluetooth.service.spec.ts
@@ -46,6 +46,7 @@ describe('BluetoothService', () => {
     }).compile();
     module.useLogger(loggerService);
     service = module.get<BluetoothService>(BluetoothService);
+    service.bleno = mockBleno;
   });
 
   describe('Bluetooth Classic', () => {

--- a/src/integration-support/bluetooth/bluetooth.service.ts
+++ b/src/integration-support/bluetooth/bluetooth.service.ts
@@ -153,6 +153,7 @@ export class BluetoothService implements OnApplicationShutdown {
       );
       peripheral.disconnect();
       peripheral.removeAllListeners();
+      await this.unlockAdapter(this._lowEnergyAdapterId);
       throw e;
     }
   }

--- a/src/integration-support/bluetooth/bluetooth.service.ts
+++ b/src/integration-support/bluetooth/bluetooth.service.ts
@@ -181,7 +181,7 @@ export class BluetoothService implements OnApplicationShutdown {
         `Failed to disconnect from ${peripheral.address}: ${e.message}`,
         e.trace
       );
-      this.resetHciDevice(this._lowEnergyAdapterId);
+      await this.resetHciDevice(this._lowEnergyAdapterId);
     }
   }
 
@@ -239,7 +239,7 @@ export class BluetoothService implements OnApplicationShutdown {
       );
 
       if (e.message === 'timed out') {
-        this.resetHciDevice(this.lowEnergyAdapterId);
+        await this.resetHciDevice(this.lowEnergyAdapterId);
       }
 
       return null;

--- a/src/integration-support/bluetooth/bluetooth.service.ts
+++ b/src/integration-support/bluetooth/bluetooth.service.ts
@@ -184,7 +184,7 @@ export class BluetoothService implements OnApplicationShutdown {
     try {
       await promiseWithTimeout(peripheral.disconnectAsync(), 1000);
     } catch (e) {
-      this.logger.error(
+      this.logger.debug(
         `Failed to disconnect from ${peripheral.address}: ${e.message}`,
         e.trace
       );
@@ -717,17 +717,17 @@ export class BluetoothService implements OnApplicationShutdown {
       try {
         await promiseWithTimeout(peripheral.connectAsync(), timeout);
       } catch (e) {
-        this.logger.debug(`ConnectAsync error ${peripheral.address}: ${e})`);
+        this.logger.debug(`Connection error ${peripheral.address}: ${e})`);
       }
       if (peripheral.state === 'connecting') {
         try {
           // Force cancellation if connection attempt timed-out
           await promiseWithTimeout(peripheral.disconnectAsync(), 1000);
-        } catch {}
+        } catch (e) {
+          this.logger.debug(`Disconnect error ${peripheral.address}: ${e})`);
+        }
       }
 
-      // TODO: Confirm with Author on required sleep delay and latest hci commit
-      //      await sleep(500); // https://github.com/mKeRix/room-assistant/issues/508
       await sleep(100);
 
       tries--;

--- a/src/integration-support/bluetooth/bluetooth.service.ts
+++ b/src/integration-support/bluetooth/bluetooth.service.ts
@@ -195,13 +195,13 @@ export class BluetoothService implements OnApplicationShutdown {
     serviceUuid: string,
     characteristicUuid: string
   ): Promise<Buffer | null> {
-    const disconnectPromise = util.promisify(target.once).bind(target)(
-      'disconnect'
-    );
-
     const peripheral = await this.connectLowEnergyDevice(target);
 
     try {
+      const disconnectPromise = util.promisify(target.once).bind(target)(
+        'disconnect'
+      );
+
       return await promiseWithTimeout<Buffer | null>(
         Promise.race([
           this.readLowEnergyCharacteristic(

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.spec.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.spec.ts
@@ -40,6 +40,8 @@ describe('BluetoothLowEnergyService', () => {
     lowEnergyScanUptime: 16 * 1000,
     onLowEnergyDiscovery: jest.fn(),
     queryLowEnergyDevice: jest.fn(),
+    acquireQueryMutex: jest.fn().mockReturnValue(true),
+    releaseQueryMutex: jest.fn(),
   };
   const clusterService = {
     on: jest.fn(),

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.ts
@@ -487,6 +487,7 @@ export class BluetoothLowEnergyService
       let appId: string;
 
       this.logger.log(`Attempting app discovery for tag ${tag.id}`);
+
       this.logger.debug(
         `Tag ${
           tag.id
@@ -495,6 +496,11 @@ export class BluetoothLowEnergyService
         )}`
       );
 
+      if (!this.bluetoothService.acquireQueryMutex()) {
+        this.logger.log(`Canceled discovery as BLE adapter is already in use`);
+        return tag;
+      }
+
       try {
         appId = await this.discoverCompanionAppId(tag);
       } catch (e) {
@@ -502,6 +508,8 @@ export class BluetoothLowEnergyService
           `Failed to discover companion app ID due to error: ${e.message}`
         );
       }
+
+      this.bluetoothService.releaseQueryMutex();
 
       if (appId != null) {
         this.logger.log(

--- a/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.ts
+++ b/src/integrations/bluetooth-low-energy/bluetooth-low-energy.service.ts
@@ -486,8 +486,12 @@ export class BluetoothLowEnergyService
     ) {
       let appId: string;
 
-      this.logger.log(`Attempting app discovery for tag ${tag.id}`);
+      if (!this.bluetoothService.acquireQueryMutex()) {
+        this.logger.debug(`Canceled discovery for tag ${tag.id} as BLE adapter is already in use`);
+        return tag;
+      }
 
+      this.logger.log(`Attempting app discovery for tag ${tag.id}`);
       this.logger.debug(
         `Tag ${
           tag.id
@@ -495,11 +499,6 @@ export class BluetoothLowEnergyService
           'hex'
         )}`
       );
-
-      if (!this.bluetoothService.acquireQueryMutex()) {
-        this.logger.log(`Canceled discovery as BLE adapter is already in use`);
-        return tag;
-      }
 
       try {
         appId = await this.discoverCompanionAppId(tag);

--- a/src/integrations/home-assistant/home-assistant.service.spec.ts
+++ b/src/integrations/home-assistant/home-assistant.service.spec.ts
@@ -501,7 +501,7 @@ describe('HomeAssistantService', () => {
 
       expect(loggerService.warn).toHaveBeenCalledWith(
         expect.stringContaining('test-instance-fictitious'),
-        expect.anything()
+        HomeAssistantService.name
       );
     });
   });

--- a/src/integrations/xiaomi-mi/xiaomi-mi.service.spec.ts
+++ b/src/integrations/xiaomi-mi/xiaomi-mi.service.spec.ts
@@ -19,6 +19,8 @@ describe('XiaomiMiService', () => {
   const bluetoothService = {
     onLowEnergyDiscovery: jest.fn(),
     queryLowEnergyDevice: jest.fn(),
+    acquireQueryMutex: jest.fn().mockReturnValue(true),
+    releaseQueryMutex: jest.fn(),
   };
   const entitiesService = {
     get: jest.fn(),

--- a/src/integrations/xiaomi-mi/xiaomi-mi.service.spec.ts
+++ b/src/integrations/xiaomi-mi/xiaomi-mi.service.spec.ts
@@ -114,7 +114,7 @@ describe('XiaomiMiService', () => {
     expect(loggerService.warn).toHaveBeenCalledTimes(1);
     expect(loggerService.warn).toHaveBeenCalledWith(
       expect.stringContaining('No sensors entries in the config'),
-      'XiaomiMiService'
+      XiaomiMiService.name
     );
   });
 
@@ -363,7 +363,7 @@ describe('XiaomiMiService', () => {
     expect(loggerService.error).toHaveBeenCalledTimes(1);
     expect(loggerService.error).toHaveBeenCalledWith(
       expect.stringContaining('Please configure a bindKey'),
-      'XiaomiMiService'
+      XiaomiMiService.name
     );
   });
 
@@ -373,7 +373,7 @@ describe('XiaomiMiService', () => {
     expect(loggerService.error).toHaveBeenCalledTimes(1);
     expect(loggerService.error).toHaveBeenCalledWith(
       expect.stringContaining('Service data length must be >= 5 bytes'),
-      'XiaomiMiService'
+      XiaomiMiService.name
     );
   });
 
@@ -388,7 +388,7 @@ describe('XiaomiMiService', () => {
     expect(loggerService.debug).toHaveBeenCalled();
     expect(loggerService.debug).toHaveBeenCalledWith(
       expect.stringContaining('supported data format not present'),
-      'XiaomiMiService'
+      XiaomiMiService.name
     );
   });
 
@@ -400,7 +400,7 @@ describe('XiaomiMiService', () => {
     expect(loggerService.error).toHaveBeenCalled();
     expect(loggerService.error).toHaveBeenCalledWith(
       expect.stringContaining('Unknown event type'),
-      'XiaomiMiService'
+      XiaomiMiService.name
     );
   });
 
@@ -537,7 +537,7 @@ describe('XiaomiMiService', () => {
     expect(loggerService.warn).toHaveBeenCalledTimes(1);
     expect(loggerService.warn).toHaveBeenCalledWith(
       expect.stringContaining('Error reading battery level'),
-      'XiaomiMiService'
+      XiaomiMiService.name
     );
   });
 

--- a/src/integrations/xiaomi-mi/xiaomi-mi.service.ts
+++ b/src/integrations/xiaomi-mi/xiaomi-mi.service.ts
@@ -324,9 +324,7 @@ export class XiaomiMiService implements OnModuleInit, OnApplicationBootstrap {
       let buffer: Buffer = null;
 
       if (!this.bluetoothService.acquireQueryMutex()) {
-        this.logger.log(
-          `Canceled battery reading as BLE adapter is already in use`
-        );
+        this.logger.debug(`${device.name}: Canceled battery reading as BLE adapter is already in use`);
         return;
       }
 


### PR DESCRIPTION
**Describe the change**
Looks to address issues identified in #852. A quick summary:

- The first two new commits address the comments [here](https://github.com/mKeRix/room-assistant/pull/852#issuecomment-894378157) and [here](https://github.com/mKeRix/room-assistant/pull/852#issuecomment-894646220).

- The next two new commits allow for aborting connection and query logic on a timeout or disconnect. Basically, I have pushed `promiseWithTimeout` down to wrap the specific Noble functions. I have retained the overall timeout duration as per master.

- The last commit refactors the "unlocking" disconnect listener as that can be handled inline at the end of `queryLowEnergyDevice` directly.

There is an outstanding question about the `sleep` call after connection attempts. I have read the noble issue and the fix recently committed on the abandonware hci repo. Unfortunately, the fix didn't make any difference for me. I also found 100ms sleep to be much better than 500ms at filtering out the erroneous disconnect events . Obviously, happy to adjust.

I have done this as a stacked PR building on the miflora_battery PR as it has allowed me to test using a large number of active devices. But I'm thinking this will make it very difficult to review. Let me know if it would help to split the commits into separate PRs and base off of main (or maybe beta). I can then fixup miflora_battery once this has landed.

I've marked as WIP as I am still soak testing this and looking at a few other tweaks but be good to get any thoughts thus far.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?
