### PR TITLE
Catch unhandled exceptions in healthcheck

### DIFF
--- a/src/status/health-indicator.service.ts
+++ b/src/status/health-indicator.service.ts
@@ -8,6 +8,7 @@ import {
   Logger,
   OnApplicationBootstrap,
   OnModuleDestroy,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
@@ -92,10 +93,15 @@ export class HealthIndicatorService
    * Sends a heartbeat to the systemd watchdog if the application is healthy.
    */
   private async updateWatchdog(): Promise<void> {
-    const healthResult = await this.check();
-
-    if (healthResult.status != 'error') {
-      notify.watchdog();
+    try {
+      const healthResult = await this.check();
+      if (healthResult.status != 'error') {
+        notify.watchdog();
+      }
+    } catch (e) {
+      if (!(e instanceof ServiceUnavailableException)) {
+        throw e;
+      }
     }
   }
 }


### PR DESCRIPTION
**Describe the change**
On Node 14, healthchecks generate an unhandled exception warning on each failed check.  See OP's relevant log in  #923. On Node 16 the first unhandled exception will instead result in an application restart. This effectively halves the watchdog window and could push more user setups into application restarts.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?

I notice MqttService healthcheck is not enabled. Let me know if it is worth plumbing in and I can add to this ?