### PR TITLE
A tiny grammar change on the documentation

### DIFF
--- a/docs/integrations/bluetooth-low-energy.md
+++ b/docs/integrations/bluetooth-low-energy.md
@@ -10,7 +10,7 @@ The integration calculates an estimated distance in meters for all advertisement
 
 ::: tip
 
-Using this together with [Bluetooth Classic](./bluetooth-classic.md) on the same adapter works, but will slightly degrade the performance. If you encounter issues you can try to run to run the integrations from different HCI devices.
+Using this together with [Bluetooth Classic](./bluetooth-classic.md) on the same adapter works, but will slightly degrade the performance. If you encounter issues you can try to run the integrations from different HCI devices.
 
 :::
 


### PR DESCRIPTION
**Describe the change**
Removed the redundant "to run" 

**Checklist**
If you changed code:
- [ ] Tests run locally and pass (`npm test`)
- [ ] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?
No
