### PR TITLE
feat: expose some config options as env variables

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -14,7 +14,7 @@ Having trouble with your configuration? You can launch room-assistant with the `
 
 ## Configuring with Docker
 
-The official [Docker image](https://hub.docker.com/r/mkerix/room-assistant/) can be configured in two different ways. You can either mount your local config folder into the container as `/room-assistant/config` or you can provide the configuration as JSON through an environment variable.
+The official [Docker image](https://hub.docker.com/r/mkerix/room-assistant/) can be configured in two different ways. You can either mount your local config folder into the container as `/room-assistant/config` or you can provide the configuration as JSON through an environment variable. Some settings may also be configured via special environment variables, in those cases the variable names are documented next to the options.
 
 ::: details Example docker-compose.yml
 
@@ -27,10 +27,10 @@ services:
     volumes:
       - /var/run/dbus:/var/run/dbus
     environment:
+      RA_GLOBAL_INSTANCE_NAME: living-room
       NODE_CONFIG: >
         {
           "global": {
-            "instanceName": "living-room",
             "integrations": ["homeAssistant", "bluetoothClassic"]
           }
         }
@@ -50,7 +50,10 @@ room-assistant exposes a few settings that affect the overall behavior of the ap
 | `integrations` | Array  |          | The integrations that should be loaded on this instance, denoted as camelCase. |
 | `apiPort`      | Number | `6415`   | The port that the REST API should be available on.           |
 
+These settings may also be configured as environment variables, using `RA_GLOBAL_INSTANCE_NAME`, `RA_GLOBAL_INTEGRATIONS` and `RA_GLOBAL_API_PORT`.
+
 ::: details Example Config
+
 ```yaml
 global:
   instanceName: bedroom

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -35,6 +35,8 @@ room-assistant makes use of the [MQTT auto discovery](https://www.home-assistant
 | `password`           | String  |         | Password for authentication                                  |
 | `rejectUnauthorized` | Boolean | `true`  | Whether MQTTS connections should fail for invalid certificates or not. Set this to `false` if you are using a self-signed certificate and connect via TLS. |
 
+Some of these settings may also be configured as environment variables, using `RA_HOME_ASSISTANT_MQTT_URL`, `RA_HOME_ASSISTANT_MQTT_USERNAME` and `RA_HOME_ASSISTANT_MQTT_PASSWORD`.
+
 ::: details Example Config
 
 ```yaml

--- a/docs/integrations/mqtt.md
+++ b/docs/integrations/mqtt.md
@@ -115,6 +115,8 @@ To get started with your automations based on these topics it is recommended to 
 | `password`           | String  |         | Password for authentication                                  |
 | `rejectUnauthorized` | Boolean | `true`  | Whether MQTTS connections should fail for invalid certificates or not. Set this to `false` if you are using a self-signed certificate and connect via TLS. |
 
+Some of these settings may also be configured as environment variables, using `RA_MQTT_MQTT_URL`, `RA_MQTT_MQTT_USERNAME` and `RA_MQTT_MQTT_PASSWORD`.
+
 ::: details Example Config
 
 ```yaml

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -2,6 +2,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "plugins": ["@nestjs/swagger/plugin"]
+    "plugins": ["@nestjs/swagger/plugin"],
+    "assets": ["config/definitions/*.yml"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "types": "dist/src/main.d.ts",
   "files": [
     "dist/**/*.{js,ts}",
+    "dist/config/definitions/*.yml",
     "bin/*.js",
     ".github/FUNDING.yml"
   ],

--- a/src/config/definitions/custom-environment-variables.yml
+++ b/src/config/definitions/custom-environment-variables.yml
@@ -1,0 +1,8 @@
+global:
+  instanceName: RA_GLOBAL_INSTANCE_NAME
+  integrations:
+    __name: RA_GLOBAL_INTEGRATIONS
+    __format: json
+  apiPort:
+    __name: RA_GLOBAL_API_PORT
+    __format: number

--- a/src/config/definitions/custom-environment-variables.yml
+++ b/src/config/definitions/custom-environment-variables.yml
@@ -6,3 +6,13 @@ global:
   apiPort:
     __name: RA_GLOBAL_API_PORT
     __format: number
+homeAssistant:
+  mqttUrl: RA_HOME_ASSISTANT_MQTT_URL
+  mqttOptions:
+    username: RA_HOME_ASSISTANT_MQTT_USERNAME
+    password: RA_HOME_ASSISTANT_MQTT_PASSWORD
+mqtt:
+  mqttUrl: RA_MQTT_MQTT_URL
+  mqttOptions:
+    username: RA_MQTT_MQTT_USERNAME
+    password: RA_MQTT_MQTT_PASSWORD


### PR DESCRIPTION
**Describe the change**

Adds custom environment variable mappings for use by node-config. For now, it only includes a subset of options as suggested in the issue which triggered this PR.

Note: I haven't tested these changes with a real installation yet, just on my dev machine. Will merge after I had time to do real world tests.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
Closes #1094.
