### PR TITLE
Change install command to prevent installation errors

### DIFF
--- a/docs/guide/quickstart-pi.md
+++ b/docs/guide/quickstart-pi.md
@@ -36,7 +36,7 @@ This page will guide you through setting up a Raspberry Pi 3 or 4 to run room-as
 
 2. We need to install some other dependencies as well, do so by running `sudo apt-get update && sudo apt-get install build-essential libavahi-compat-libdnssd-dev libsystemd-dev bluetooth libbluetooth-dev libudev-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev`.
 
-3. Now let's get install room-assistant! Run `sudo npm i --global --unsafe-perm room-assistant`. You will see messages like the one shown below during the installation process. Don't worry about them - they're not errors!
+3. Now let's get install room-assistant! Run `sudo npm i --global --unsafe-perm --verbose --foreground-scripts room-assistant`. You will see messages like the one shown below during the installation process. Don't worry about them - they're not errors!
 
    ![compilation messages](./compilation-msgs.png)
 


### PR DESCRIPTION
With this slightly changed command, the Raspberry Pi Zero 2 W board doesn't stall on installation. This has something to do with RAM: https://github.com/mKeRix/room-assistant/discussions/967#discussioncomment-1684004

Because of the new chipset, people should follow the Raspberry Pi 3/4 instructions for the Zero 2 instead of following the Zero 1 board instructions. You might want to add this yourself.

Have a nice day!

**Describe the change**
I added >--verbose --foreground-scripts< to the install script.

**Checklist**
If you changed code:
- [ ] Tests run locally and pass (`npm test`)
- [ ] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
This PR is related to installation errors on the Raspberry Pi Zero 2 W. 
