### PR TITLE
Update quickstart-pi-zero-w.md

### DIFF
--- a/docs/guide/quickstart-pi-zero-w.md
+++ b/docs/guide/quickstart-pi-zero-w.md
@@ -37,7 +37,7 @@ This page will guide you through setting up a Pi Zero W to run room-assistant.
 
 3. We need to install some other dependencies as well, do so by running `sudo apt-get update && sudo apt-get install build-essential libavahi-compat-libdnssd-dev libsystemd-dev bluetooth libbluetooth-dev libudev-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev`.
 
-4. Now let's get install room-assistant! Run `sudo npm i --global --unsafe-perm room-assistant`. You will see messages like the one shown below during the installation process. Don't worry about them - they're not errors!
+4. Now let's get install room-assistant! Run `sudo npm i --location=global --unsafe-perm room-assistant`. You will see messages like the one shown below during the installation process. Don't worry about them - they're not errors!
 
    ![compilation messages](./compilation-msgs.png)
 


### PR DESCRIPTION
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.

**Describe the change**
A clear and concise description of what you changed.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?
