### PR TITLE
Updated default user 'pi' to <user>

### DIFF
--- a/docs/guide/quickstart-pi-zero-w.md
+++ b/docs/guide/quickstart-pi-zero-w.md
@@ -95,17 +95,18 @@ When starting room-assistant you will see warnings about the Apple Bonjour compa
    [Service]
    Type=notify
    ExecStart=/opt/nodejs/bin/room-assistant
-   WorkingDirectory=/home/pi/room-assistant
+   WorkingDirectory=/home/<user>/room-assistant
    TimeoutStartSec=120
    TimeoutStopSec=30
    Restart=always
    RestartSec=10
    WatchdogSec=60
-   User=pi
+   User=<user>
    
    [Install]
    WantedBy=multi-user.target
    ```
+   Note: The new Raspbian installer prompts you to name the user so the default users is no longer 'pi'. Replace <user> by whatever you used during the installation of Raspbian.
 
 3. Enable and start your service by executing the commands below.
 


### PR DESCRIPTION
The installation script of Raspbian has changed asking you to name the default user. So instead of 'pi' the default username is created during setup.

**Describe the change**
A clear and concise description of what you changed.

**Checklist**
If you changed code:
- [ ] Tests run locally and pass (`npm test`)
- [ ] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?
