### PR TITLE
Fix for issue 1475 - Warning about device name in Home Assistant

### DIFF
--- a/src/integrations/bluetooth-classic/bluetooth-classic.service.ts
+++ b/src/integrations/bluetooth-classic/bluetooth-classic.service.ts
@@ -314,7 +314,7 @@ export class BluetoothClassicService
     const inquiriesSwitch = this.entitiesService.add(
       new Switch(
         'bluetooth-classic-inquiries-switch',
-        `${instanceName} Bluetooth Inquiries`
+        `Bluetooth Inquiries`
       ),
       customizations
     ) as Switch;
@@ -351,7 +351,7 @@ export class BluetoothClassicService
 
     const deviceTracker = this.createDeviceTracker(
       makeId(`${sensorId}-tracker`),
-      `${baseName} Tracker`,
+      `Tracker`,
       deviceInfo
     );
 
@@ -366,7 +366,7 @@ export class BluetoothClassicService
     ];
     const rawSensor = new RoomPresenceDistanceSensor(
       sensorId,
-      `${baseName} Room Presence`,
+      `Room Presence`,
       0
     );
     const sensorProxy = new Proxy<RoomPresenceDistanceSensor>(

--- a/src/integrations/xiaomi-mi/xiaomi-mi.service.ts
+++ b/src/integrations/xiaomi-mi/xiaomi-mi.service.ts
@@ -152,7 +152,7 @@ export class XiaomiMiService implements OnModuleInit, OnApplicationBootstrap {
         },
       ];
       entity = this.entitiesService.add(
-        new Sensor(id, `${device.name} ${sensor.name}`, true, false),
+        new Sensor(id, `${sensor.name}`, true, false),
         customizations
       ) as Sensor;
     }

--- a/src/status/status.service.ts
+++ b/src/status/status.service.ts
@@ -71,7 +71,7 @@ export class StatusService implements OnApplicationBootstrap {
       },
     ];
     const clusterSizeSensor = this.entitiesService.add(
-      new Sensor('status-cluster-size', `${instanceName} Cluster Size`),
+      new Sensor('status-cluster-size', `Cluster Size`),
       customizations
     );
 
@@ -94,7 +94,7 @@ export class StatusService implements OnApplicationBootstrap {
       },
     ];
     const clusterLeaderSensor = this.entitiesService.add(
-      new Sensor('status-cluster-leader', `${instanceName} Cluster Leader`),
+      new Sensor('status-cluster-leader', `Cluster Leader`),
       customizations
     );
 


### PR DESCRIPTION
Home assistant now shows a warning about device names being repeated in sensor names. This change stops adding the device name in the Xiaomi integration which fixed the error for me. Home assistant needs to receive new data with the new names then be restarted for warnings to disappear.

**Describe the change**
I changed the integration for Xiaomi to not send the device name when creating new entities. Its a simple one line fix.

**Checklist**
If you changed code:
- [x] Tests run locally and pass (`npm test`)
- [x] Code has correct format (`npm run format`)

If you added a new integration:
- [ ] Documentation page added in `docs/integrations/`
- [ ] Page linked in `docs/.vuepress/config.ts` and `docs/integrations/README.md`

**Additional information**
Is this PR related to any issues? Do you have anything else to add?
